### PR TITLE
Fixing empty spellbook.

### DIFF
--- a/OrionUO/Managers/PacketManager.cpp
+++ b/OrionUO/Managers/PacketManager.cpp
@@ -2327,7 +2327,7 @@ PACKET_HANDLER(OpenContainer)
         if (obj != NULL)
         {
             /*if (gumpid != 0xFFFF)*/ obj->Opened = true;
-            if (!obj->IsCorpse())
+            if (!obj->IsCorpse() && gumpid != 0xFFFF)
                 g_World->ClearContainer(obj);
 
             if (gumpid == 0xFFFF)


### PR DESCRIPTION
Most emulators sends spellbook content via 0xBF/0x1B packet after opening related gump (packet 0x24). But some emulators send content first (packet 0x3C), then open related gump and they don't send any 0xBF packet afterwards. This is a behavior of old Sphere versions, specifically Sphere 0.99gz when client reports 306m version.

This should not break anything. The reasoning goes: both packet handlers (0xBF/0x1B and 0x3C) clears container content before adding any further spells - spells duplication should not be possible. Not sure about other cases. That is the reason why `g_world->ClearContainer` is excluded only for spellbooks.