### PR TITLE
Fixes #75 - Remove use of Client.cuo

### DIFF
--- a/CMake/ClangFormat.cmake
+++ b/CMake/ClangFormat.cmake
@@ -37,15 +37,15 @@ if (CLANG_FORMAT)
     set(CCOMMENT "Running clang format against all the .h and .cpp files in OrionUO/")
     if (WIN32)
         add_custom_target(clang-format
-            COMMAND powershell.exe -Command "Get-ChildItem ${SRCS}/* -Include *.cpp,*.h -Recurse | Foreach {${CLANG_FORMAT} -i $_.fullname}"
+            COMMAND powershell.exe -Command "Get-ChildItem ${SRCS}/* -Include *.cpp,*.h -Recurse | Foreach {${CLANG_FORMAT} --style=file -i $_.fullname}"
             COMMENT ${CCOMMENT})
     elseif(MINGW)
         add_custom_target(clang-format
-            COMMAND find `cygpath -u ${SRCS}` -iname *.h -o -iname *.cpp | xargs `cygpath -u ${CLANG_FORMAT}` -i
+            COMMAND find `cygpath -u ${SRCS}` -iname *.h -o -iname *.cpp | xargs `cygpath -u ${CLANG_FORMAT}` --style=file -i
             COMMENT ${CCOMMENT})
     else()
         add_custom_target(clang-format
-            COMMAND find ${SRCS} -iname *.h -o -iname *.cpp | xargs ${CLANG_FORMAT} -i
+            COMMAND ${CLANG_FORMAT} --style=file -i ${SRCS}/**/**.{h,cpp}
             COMMENT ${CCOMMENT})
     endif()
     unset(SRCS)

--- a/OrionUO/CMakeLists.txt
+++ b/OrionUO/CMakeLists.txt
@@ -348,6 +348,7 @@ set(orion_src
   Sockets.cpp
   OrionMain.cpp
   Platform.cpp
+  Config.cpp
 )
 
 if(ORION_WINDOWS)

--- a/OrionUO/CharacterList.h
+++ b/OrionUO/CharacterList.h
@@ -10,7 +10,6 @@ public:
     bool OnePerson = false;
     bool Have6Slot = false;
     bool Have7Slot = false;
-    uint16_t ClientFlag = 0;
 
     string LastCharacterName;
 

--- a/OrionUO/Config.cpp
+++ b/OrionUO/Config.cpp
@@ -220,8 +220,10 @@ static void SetClientCrypt(uint32_t version)
     {
         g_Config.EncryptionType = ET_203;
     }
-
-    g_Config.EncryptionType = ET_TFISH;
+    else
+    {
+        g_Config.EncryptionType = ET_TFISH;
+    }
 }
 
 static void ClientVersionFixup(const char *versionStr)
@@ -257,7 +259,7 @@ static void ClientVersionFixup(const char *versionStr)
     }
 
     LOG("\tEmulation Compatibility Version: %s%s (0x%08x)\n", p1, p2, g_Config.ClientVersion);
-    LOG("\tCrypto: %08x %08x %08x %04x (%d)\n",
+    LOG("\tCryptography: %08x %08x %08x %04x (%d)\n",
         g_Config.Key1,
         g_Config.Key2,
         g_Config.Key3,

--- a/OrionUO/Config.cpp
+++ b/OrionUO/Config.cpp
@@ -424,6 +424,7 @@ void SaveGlobalConfig()
     }
 
     fprintf(cfg, "ClientVersion=%s\n", g_Config.ClientVersionString.c_str());
+    fprintf(cfg, "Crypt=%s\n", (g_Config.UseCrypt ? "yes" : "no"));
 
     fflush(cfg);
     fs_close(cfg);

--- a/OrionUO/Config.cpp
+++ b/OrionUO/Config.cpp
@@ -1,0 +1,428 @@
+// GPLv3 License
+// Copyright (C) 2019 Danny Angelo Carminati Grein
+
+#include "Config.h"
+
+#include <string>
+
+#include "Globals.h"
+#include "FileSystem.h"
+#include "OrionApplication.h"
+#include "plugin/enumlist.h"
+#include "Crypt/CryptEntry.h"
+#include "Wisp/WispDefinitions.h"
+#include "Wisp/WispLogger.h"
+#include "Wisp/WispTextFileParser.h"
+
+#define ORIONUO_CONFIG "OrionUO.cfg"
+
+Config g_Config;
+
+enum
+{
+    MSCC_NONE,
+    MSCC_ACTID,
+    MSCC_ACTPWD,
+    MSCC_REMEMBERPWD,
+    MSCC_AUTOLOGIN,
+    MSCC_THE_ABYSS,
+    MSCC_ASMUT,
+    MSCC_CUSTOM_PATH,
+    MSCC_LOGIN_SERVER,
+    MSCC_CLIENT_VERSION,
+    MSCC_USE_CRYPT,
+    MSCC_COUNT,
+};
+
+namespace config
+{
+struct ConfigEntry
+{
+    uint32_t key;
+    const char *key_name;
+};
+
+static const ConfigEntry s_Keys[] = {
+    { MSCC_ACTID, "acctid" },
+    { MSCC_ACTPWD, "acctpassword" },
+    { MSCC_REMEMBERPWD, "rememberacctpw" },
+    { MSCC_AUTOLOGIN, "autologin" },
+    { MSCC_THE_ABYSS, "theabyss" },
+    { MSCC_ASMUT, "asmut" },
+    { MSCC_CUSTOM_PATH, "custompath" },
+    { MSCC_LOGIN_SERVER, "loginserver" },
+    { MSCC_CLIENT_VERSION, "clientversion" },
+    { MSCC_USE_CRYPT, "crypt" },
+    { MSCC_COUNT, nullptr },
+};
+
+static uint32_t GetConfigKey(const string &key)
+{
+    auto str = ToLowerA(key);
+    for (int i = 0; s_Keys[i].key_name; i++)
+    {
+        if (str == s_Keys[i].key_name)
+        {
+            return s_Keys[i].key;
+        }
+    }
+    return MSCC_NONE;
+}
+
+} // namespace config
+
+static void SetClientVersion(const char *versionStr)
+{
+    DEBUG_TRACE_FUNCTION;
+
+    if (!versionStr || !versionStr[0])
+    {
+        g_Config.ClientVersion = CV_LATEST;
+        return;
+    }
+
+    int a = 0, b = 0, c = 0, d = 0;
+    char extra[16]{};
+    char tok = 0;
+    sscanf(versionStr, "%d.%d.%d%s", &a, &b, &c, extra);
+
+    if (strlen(extra))
+    {
+        tok = extra[0];
+        if (tok == '.')
+        {
+            sscanf(extra, ".%d", &d);
+        }
+        else if (tok >= 'a' && tok <= 'z')
+        {
+            d = tok;
+        }
+    }
+
+    LOG("\tClient Version: %s\n", versionStr);
+    g_Config.ClientVersion = VERSION(a, b, c, d);
+
+    /*
+    // This was to keep compatibility, but using
+    // g_Config.ClientVersion is wrong!
+    static CLIENT_VERSION protocolVersion[] = {
+        CV_OLD,  CV_200,  CV_200X,  CV_300,   CV_305D,  CV_306E,  CV_308,   CV_308D,
+        CV_308J, CV_308Z, CV_400B,  CV_405A,  CV_4011D, CV_500A,  CV_5020,  CV_5090,
+        CV_6000, CV_6013, CV_60144, CV_6017,  CV_6040,  CV_6060,  CV_60142, CV_60144,
+        CV_7000, CV_7090, CV_70130, CV_70160, CV_70180, CV_70240, CV_70331
+    };
+
+    for (int i = countof(protocolVersion) - 1; i > 0; --i)
+    {
+        if (g_Config.ClientVersion >= (int32_t)protocolVersion[i])
+            return protocolVersion[i];
+    }
+    return CV_OLD;
+*/
+}
+
+static const char *GetClientTypeName(CLIENT_FLAG clientFlag)
+{
+    switch (clientFlag)
+    {
+        case CF_T2A:
+            return "The Second Age (T2A)";
+        case CF_RE:
+            return "Renaissance";
+        case CF_TD:
+            return "Third Dawn";
+        case CF_LBR:
+            return "Lord Blackthorn's Revenge";
+        case CF_AOS:
+            return "Age Of Shadows";
+        case CF_SE:
+            return "Samurai Empire";
+        case CF_SA:
+            return "Stygian Abyss";
+        case CF_UO3D:
+            return "UO3D";
+        case CF_RESERVED:
+            return "Reserved";
+        case CF_3D:
+            return "3D Client";
+    }
+    return "Unknown";
+}
+
+static CLIENT_FLAG GetClientType(uint32_t version)
+{
+    if (version < CV_200)
+    {
+        return CF_T2A;
+    }
+    if (version < CV_300)
+    {
+        return CF_RE;
+    }
+    if (version < CV_308)
+    {
+        return CF_TD;
+    }
+    if (version < CV_308Z)
+    {
+        return CF_LBR;
+    }
+    if (version < CV_405A)
+    {
+        // >=3.0.8z
+        return CF_AOS;
+    }
+    if (version < CV_60144)
+    {
+        return CF_SE;
+    }
+    return CF_SA;
+}
+
+// Reference: https://github.com/polserver/polserver/blob/5c747bb88123945bb892d3d793b89afcb1dc645a/pol-core/pol/crypt/cryptkey.cpp
+static void SetClientCrypt(uint32_t version)
+{
+    if (version == CV_200X)
+    {
+        g_Config.Key1 = 0x2D13A5FC;
+        g_Config.Key2 = 0x2D13A5FD;
+        g_Config.Key3 = 0xA39D527F;
+        g_Config.EncryptionType = ET_203;
+        return;
+    }
+
+    int a = (version >> 24) & 0xff;
+    int b = (version >> 16) & 0xff;
+    int c = (version >> 8) & 0xff;
+
+    int temp = ((a << 9 | b) << 10 | c) ^ ((c * c) << 5);
+    g_Config.Key2 = (temp << 4) ^ (b * b) ^ (b * 0x0B000000) ^ (c * 0x380000) ^ 0x2C13A5FD;
+    temp = (((a << 9 | c) << 10 | b) * 8) ^ (c * c * 0x0c00);
+    g_Config.Key3 = temp ^ (b * b) ^ (b * 0x6800000) ^ (c * 0x1c0000) ^ 0x0A31D527F;
+
+    // Configurator does this, not sure why
+    // lets keep compatibility until we understand more
+    g_Config.Key1 = g_Config.Key2 - 1;
+
+    if (version < VERSION(1, 25, 35, 0))
+    {
+        g_Config.EncryptionType = ET_OLD_BFISH;
+    }
+    else if (version == VERSION(1, 25, 36, 0))
+    {
+        g_Config.EncryptionType = ET_1_25_36;
+    }
+    else if (version < CV_200)
+    {
+        g_Config.EncryptionType = ET_BFISH;
+    }
+    else if (version <= VERSION(2, 0, 3, 0))
+    {
+        g_Config.EncryptionType = ET_203;
+    }
+
+    g_Config.EncryptionType = ET_TFISH;
+}
+
+static void ClientVersionFixup(const char *versionStr)
+{
+    DEBUG_TRACE_FUNCTION;
+
+    LOG("Client Emulation:\n");
+    SetClientVersion(versionStr);
+    SetClientCrypt(g_Config.ClientVersion);
+
+    const bool useVerdata = g_Config.ClientVersion < CV_500A;
+    const auto clientType = GetClientType(g_Config.ClientVersion);
+
+    if (g_Config.ClientVersion < CV_500A)
+    {
+        g_MapSize[0].Width = 6144;
+        g_MapSize[1].Width = 6144;
+    }
+
+    int a = (g_Config.ClientVersion >> 24) & 0xff;
+    int b = (g_Config.ClientVersion >> 16) & 0xff;
+    int c = (g_Config.ClientVersion >> 8) & 0xff;
+    int d = (g_Config.ClientVersion & 0xff);
+    char p1[64], p2[8];
+    snprintf(p1, sizeof(p1), "%d.%d.%d", a, b, c);
+    if (d >= 'a' && d <= 'z')
+    {
+        snprintf(p2, sizeof(p2), "%c", d);
+    }
+    else
+    {
+        snprintf(p2, sizeof(p2), ".%d", d);
+    }
+
+    LOG("\tEmulation Compatibility Version: %s%s (0x%08x)\n", p1, p2, g_Config.ClientVersion);
+    LOG("\tCrypto: %08x %08x %08x %04x (%d)\n",
+        g_Config.Key1,
+        g_Config.Key2,
+        g_Config.Key3,
+        g_Config.Seed,
+        g_Config.EncryptionType);
+    LOG("\tClient Type: %s (%d)\n", GetClientTypeName(clientType), clientType);
+    LOG("\tUse Verdata: %d\n", useVerdata);
+
+    if (!g_Config.UseCrypt)
+    {
+        g_Config.EncryptionType = ET_NOCRYPT;
+    }
+
+    if (g_Config.ClientVersion >= CV_70331)
+    {
+        g_MaxViewRange = MAX_VIEW_RANGE_NEW;
+    }
+    else
+    {
+        g_MaxViewRange = MAX_VIEW_RANGE_OLD;
+    }
+
+    g_PacketManager.ConfigureClientVersion(g_Config.ClientVersion);
+    g_Config.ClientFlag = clientType;
+    g_Config.UseVerdata = useVerdata;
+}
+
+void GetClientVersion(uint32_t *major, uint32_t *minor, uint32_t *rev, uint32_t *proto)
+{
+    if (major)
+    {
+        *major = (g_Config.ClientVersion >> 24) & 0xff;
+    }
+
+    if (minor)
+    {
+        *minor = (g_Config.ClientVersion >> 16) & 0xff;
+    }
+
+    if (rev)
+    {
+        *rev = (g_Config.ClientVersion >> 8) & 0xff;
+    }
+
+    if (proto)
+    {
+        *proto = (g_Config.ClientVersion & 0xff);
+    }
+}
+
+void LoadGlobalConfig()
+{
+    DEBUG_TRACE_FUNCTION;
+
+    LOG("Loading global config from " ORIONUO_CONFIG "\n");
+    Wisp::CTextFileParser file(g_App.ExeFilePath(ORIONUO_CONFIG), "=,", "#;", "");
+
+    while (!file.IsEOF())
+    {
+        auto strings = file.ReadTokens();
+        if (strings.size() >= 2)
+        {
+            const auto key = config::GetConfigKey(strings[0]);
+            switch (key)
+            {
+                case MSCC_CLIENT_VERSION:
+                {
+                    g_Config.ClientVersionString = strings[1];
+                    ClientVersionFixup(strings[1].c_str());
+                }
+                break;
+                case MSCC_CUSTOM_PATH:
+                {
+                    g_App.m_UOPath = ToPath(strings[1]);
+                    fs_case_insensitive_init(g_App.m_UOPath);
+                }
+                break;
+                case MSCC_ACTID:
+                {
+                    g_Config.Login = strings[1];
+                    break;
+                }
+                case MSCC_ACTPWD:
+                {
+                    string password = file.RawLine;
+                    size_t pos = password.find_first_of('=');
+                    g_Config.Password = password.substr(pos + 1, password.length() - (pos + 1));
+                    break;
+                }
+                case MSCC_REMEMBERPWD:
+                {
+                    g_Config.SavePassword = ToBool(strings[1]);
+                    break;
+                }
+                case MSCC_AUTOLOGIN:
+                {
+                    g_Config.AutoLogin = ToBool(strings[1]);
+                    break;
+                }
+                case MSCC_THE_ABYSS:
+                {
+                    g_Config.TheAbyss = ToBool(strings[1]);
+                    break;
+                }
+                case MSCC_ASMUT:
+                {
+                    g_Config.Asmut = ToBool(strings[1]);
+                    break;
+                }
+                case MSCC_LOGIN_SERVER:
+                {
+                    g_Config.ServerAddress = strings[1];
+                    g_Config.ServerPort = ToInt(strings[2]);
+                    break;
+                }
+                case MSCC_USE_CRYPT:
+                {
+                    g_Config.UseCrypt = ToBool(strings[1]);
+                    break;
+                }
+                default:
+                    break;
+            }
+        }
+    }
+}
+
+void SaveGlobalConfig()
+{
+    DEBUG_TRACE_FUNCTION;
+    LOG("Saving global config to " ORIONUO_CONFIG "\n");
+    FILE *cfg = fs_open(g_App.ExeFilePath(ORIONUO_CONFIG), FS_WRITE);
+    if (cfg == nullptr)
+    {
+        return;
+    }
+
+    fprintf(cfg, "AcctID=%s\n", g_Config.Login.c_str());
+    if (g_Config.SavePassword)
+    {
+        fprintf(cfg, "AcctPassword=%s\n", g_Config.Password.c_str());
+        fprintf(cfg, "RememberAcctPW=yes\n");
+    }
+    else
+    {
+        fprintf(cfg, "AcctPassword=\n");
+        fprintf(cfg, "RememberAcctPW=no\n");
+    }
+
+    fprintf(cfg, "AutoLogin=%s\n", (g_Config.AutoLogin ? "yes" : "no"));
+    fprintf(cfg, "TheAbyss=%s\n", (g_Config.TheAbyss ? "yes" : "no"));
+    fprintf(cfg, "Asmut=%s\n", (g_Config.Asmut ? "yes" : "no"));
+
+    if (g_App.m_UOPath != g_App.m_ExePath)
+    {
+        fprintf(cfg, "CustomPath=%s\n", CStringFromPath(g_App.m_UOPath));
+    }
+
+    if (!g_Config.ServerAddress.empty())
+    {
+        fprintf(cfg, "LoginServer=%s,%d\n", g_Config.ServerAddress.c_str(), g_Config.ServerPort);
+    }
+
+    fprintf(cfg, "ClientVersion=%s\n", g_Config.ClientVersionString.c_str());
+
+    fflush(cfg);
+    fs_close(cfg);
+}

--- a/OrionUO/Config.h
+++ b/OrionUO/Config.h
@@ -1,0 +1,37 @@
+// GPLv3 License
+// Copyright (C) 2019 Danny Angelo Carminati Grein
+
+#pragma once
+
+#include <string>
+
+struct Config
+{
+  std::string Login;
+  std::string Password;
+  std::string ClientVersionString = "7.0.33.1";
+  std::string CustomPath;
+  std::string ServerAddress;
+  uint16_t ServerPort = 2593;
+  bool SavePassword = false;
+  bool AutoLogin = false;
+  bool TheAbyss = false;
+  bool Asmut = false;
+  bool UseVerdata = false;
+  bool UseCrypt = false;
+
+  // Calculated stuff that are not saved back
+  uint16_t Seed = 0x1357;
+  uint32_t Key1 = 0;
+  uint32_t Key2 = 0;
+  uint32_t Key3 = 0;
+  uint32_t ClientVersion = 0;
+  uint32_t EncryptionType = 0;
+  uint16_t ClientFlag = 0;
+};
+
+void GetClientVersion(uint32_t *major, uint32_t *minor, uint32_t *rev, uint32_t *proto = nullptr);
+void LoadGlobalConfig();
+void SaveGlobalConfig();
+
+extern Config g_Config;

--- a/OrionUO/Config.h
+++ b/OrionUO/Config.h
@@ -7,27 +7,27 @@
 
 struct Config
 {
-  std::string Login;
-  std::string Password;
-  std::string ClientVersionString = "7.0.33.1";
-  std::string CustomPath;
-  std::string ServerAddress;
-  uint16_t ServerPort = 2593;
-  bool SavePassword = false;
-  bool AutoLogin = false;
-  bool TheAbyss = false;
-  bool Asmut = false;
-  bool UseVerdata = false;
-  bool UseCrypt = false;
+    std::string Login;
+    std::string Password;
+    std::string ClientVersionString = "7.0.33.1";
+    std::string CustomPath;
+    std::string ServerAddress;
+    uint16_t ServerPort = 2593;
+    bool SavePassword = false;
+    bool AutoLogin = false;
+    bool TheAbyss = false;
+    bool Asmut = false;
+    bool UseVerdata = false;
+    bool UseCrypt = false;
 
-  // Calculated stuff that are not saved back
-  uint16_t Seed = 0x1357;
-  uint32_t Key1 = 0;
-  uint32_t Key2 = 0;
-  uint32_t Key3 = 0;
-  uint32_t ClientVersion = 0;
-  uint32_t EncryptionType = 0;
-  uint16_t ClientFlag = 0;
+    // Calculated stuff that are not saved back
+    uint16_t Seed = 0x1357;
+    uint32_t Key1 = 0;
+    uint32_t Key2 = 0;
+    uint32_t Key3 = 0;
+    uint32_t ClientVersion = 0;
+    uint32_t EncryptionType = 0;
+    uint16_t ClientFlag = 0;
 };
 
 void GetClientVersion(uint32_t *major, uint32_t *minor, uint32_t *rev, uint32_t *proto = nullptr);

--- a/OrionUO/Crypt/CryptEntry.cpp
+++ b/OrionUO/Crypt/CryptEntry.cpp
@@ -1,18 +1,18 @@
 
-#if !USE_ORIONDLL
 #include "CryptEntry.h"
 #include "../Wisp/WispGlobal.h"
 #include "../Wisp/WispDataStream.h"
 #include "../plugin/enumlist.h"
 #include "../plugin/plugininterface.h"
+#include "../Config.h"
 #include "LoginCrypt.h"
 #include "GameCrypt.h"
 
-ENCRYPTION_TYPE g_EncryptionType = ET_NOCRYPT;
 static size_t s_CryptPluginsCount = 0;
-vector<uint8_t> g_RawData;
 
-static void Init(bool is_login, uint8_t seed[4])
+namespace Crypt
+{
+void Init(bool is_login, uint8_t seed[4])
 {
     if (is_login)
     {
@@ -20,15 +20,15 @@ static void Init(bool is_login, uint8_t seed[4])
     }
     else
     {
-        if (g_EncryptionType != ET_NOCRYPT)
+        if (g_Config.EncryptionType != ET_NOCRYPT)
         {
             g_BlowfishCrypt.Init();
         }
 
-        if (g_EncryptionType == ET_203 || g_EncryptionType == ET_TFISH)
+        if (g_Config.EncryptionType == ET_203 || g_Config.EncryptionType == ET_TFISH)
         {
             g_TwofishCrypt.Init(seed);
-            if (g_EncryptionType == ET_TFISH)
+            if (g_Config.EncryptionType == ET_TFISH)
             {
                 g_TwofishCrypt.Init_MD5();
             }
@@ -36,33 +36,33 @@ static void Init(bool is_login, uint8_t seed[4])
     }
 }
 
-static void Send(bool is_login, uint8_t *src, uint8_t *dest, int size)
+void Encrypt(bool is_login, uint8_t *src, uint8_t *dest, int size)
 {
-    if (g_EncryptionType == ET_NOCRYPT)
+    if (g_Config.EncryptionType == ET_NOCRYPT)
     {
         memcpy(dest, src, size);
     }
     else if (is_login)
     {
-        if (g_EncryptionType == ET_OLD_BFISH)
+        if (g_Config.EncryptionType == ET_OLD_BFISH)
         {
             g_LoginCrypt.Encrypt_Old(src, dest, size);
         }
-        else if (g_EncryptionType == ET_1_25_36)
+        else if (g_Config.EncryptionType == ET_1_25_36)
         {
             g_LoginCrypt.Encrypt_1_25_36(src, dest, size);
         }
-        else if (g_EncryptionType != ET_NOCRYPT)
+        else if (g_Config.EncryptionType != ET_NOCRYPT)
         {
             g_LoginCrypt.Encrypt(src, dest, size);
         }
     }
-    else if (g_EncryptionType == ET_203)
+    else if (g_Config.EncryptionType == ET_203)
     {
         g_BlowfishCrypt.Encrypt(src, dest, size);
         g_TwofishCrypt.Encrypt(dest, dest, size);
     }
-    else if (g_EncryptionType == ET_TFISH)
+    else if (g_Config.EncryptionType == ET_TFISH)
     {
         g_TwofishCrypt.Encrypt(src, dest, size);
     }
@@ -72,9 +72,9 @@ static void Send(bool is_login, uint8_t *src, uint8_t *dest, int size)
     }
 }
 
-static void Decrypt(uint8_t *src, uint8_t *dest, int size)
+void Decrypt(uint8_t *src, uint8_t *dest, int size)
 {
-    if (g_EncryptionType == ET_TFISH)
+    if (g_Config.EncryptionType == ET_TFISH)
     {
         g_TwofishCrypt.Decrypt(src, dest, size);
     }
@@ -84,142 +84,9 @@ static void Decrypt(uint8_t *src, uint8_t *dest, int size)
     }
 }
 
-static void LoadPlugins(PLUGIN_INFO *result)
-{
-    if (static_cast<unsigned int>(!g_RawData.empty()) != 0u)
-    {
-        Wisp::CDataReader file(&g_RawData[0], (int)g_RawData.size());
-
-        uint8_t ver = file.ReadUInt8();
-
-        file.Move(2);
-        int len = file.ReadUInt8();
-        file.Move(len + 39);
-
-        if (ver >= 2)
-        {
-            file.Move(1);
-
-            if (ver >= 3)
-            {
-                file.Move(1);
-            }
-
-            char count = file.ReadInt8();
-
-            for (int i = 0; i < count; i++)
-            {
-                short len = file.ReadInt16LE();
-                string fileName = file.ReadString(len);
-                memcpy(&result[i].FileName[0], &fileName[0], fileName.length());
-
-                file.Move(2);
-                result[i].Flags = file.ReadUInt32LE();
-                file.Move(2);
-
-                len = file.ReadInt16LE();
-                string functionName = file.ReadString(len);
-                memcpy(&result[i].FunctionName[0], &functionName[0], functionName.length());
-            }
-        }
-    }
-}
-
-vector<uint8_t> ApplyInstall(uint8_t *address, size_t size)
-{
-    vector<uint8_t> result;
-
-    if (size != 0u)
-    {
-        g_RawData.resize(size);
-        memcpy(&g_RawData[0], &address[0], size);
-
-        Wisp::CDataReader file(address, size);
-        Wisp::CDataWriter writer;
-
-        uint8_t version = file.ReadInt8();
-        writer.WriteUInt8(version);
-        writer.WriteUInt8(0xFE); //dll version
-        writer.WriteUInt8(0);    //sub version
-
-        g_EncryptionType = (ENCRYPTION_TYPE)file.ReadInt8();
-        writer.WriteUInt8(file.ReadInt8()); //ClientVersion
-
-        int len = file.ReadInt8();
-        writer.WriteUInt8(len);
-        writer.WriteDataLE((uint8_t *)file.ReadString(len).data(), len, 0);
-
-        file.Move(14); //crypt keys & seed
-#if defined(_M_IX86)
-        writer.WriteUInt32LE((size_t)Init);
-        writer.WriteUInt32LE((size_t)Send);
-        writer.WriteUInt32LE((size_t)Decrypt);
-        writer.WriteUInt32LE((size_t)LoadPlugins);
-#else
-        writer.WriteUInt64LE((size_t)Init);
-        writer.WriteUInt64LE((size_t)Send);
-        writer.WriteUInt64LE((size_t)Decrypt);
-        writer.WriteUInt64LE((size_t)LoadPlugins);
-#endif
-
-        int mapsCount = 6;
-
-        if (version < 4)
-        {
-            writer.WriteUInt8(file.ReadInt8()); //InverseBuylist
-        }
-        else
-        {
-            mapsCount = file.ReadInt8();
-            writer.WriteUInt8(mapsCount);
-        }
-
-        for (int i = 0; i < mapsCount; i++)
-        {
-            writer.WriteUInt16LE(file.ReadUInt16LE());
-            writer.WriteUInt16LE(file.ReadUInt16LE());
-        }
-
-        uint8_t clientFlag = 0;
-        uint8_t useVerdata = 0;
-
-        if (version >= 2)
-        {
-            clientFlag = file.ReadInt8();
-
-            if (version >= 3)
-            {
-                useVerdata = file.ReadInt8();
-            }
-
-            s_CryptPluginsCount = file.ReadInt8();
-        }
-
-        writer.WriteUInt8(clientFlag);
-        writer.WriteUInt8(useVerdata);
-
-        result = writer.Data();
-    }
-
-    //ParseCommandLine();
-
-    return result;
-}
-
 size_t GetPluginsCount()
 {
     return s_CryptPluginsCount;
 }
 
-void CryptInstallNew(uint8_t *address, size_t size, uint8_t *result, size_t &resultSize)
-{
-    assert(address && result && size && resultSize);
-    vector<uint8_t> buf = ApplyInstall(address, size);
-    memset(result, 0, resultSize);
-    resultSize = buf.size();
-    if (resultSize >= buf.size())
-    {
-        memcpy(result, &buf[0], buf.size());
-    }
-}
-#endif
+} // namespace Crypt

--- a/OrionUO/Crypt/CryptEntry.h
+++ b/OrionUO/Crypt/CryptEntry.h
@@ -1,8 +1,10 @@
 #pragma once
 
-extern ENCRYPTION_TYPE g_EncryptionType;
+namespace Crypt {
 
-#if !USE_ORIONDLL
-size_t GetPluginsCount();
-void CryptInstallNew(uint8_t *address, size_t size, uint8_t *result, size_t &resultSize);
-#endif
+void Init(bool is_login, uint8_t seed[4]);
+void Encrypt(bool is_login, uint8_t *src, uint8_t *dest, int size);
+void Decrypt(uint8_t *src, uint8_t *dest, int size);
+size_t GetPluginsCount(); // FIXME: move this out
+
+}

--- a/OrionUO/Crypt/CryptEntry.h
+++ b/OrionUO/Crypt/CryptEntry.h
@@ -1,10 +1,10 @@
 #pragma once
 
-namespace Crypt {
-
+namespace Crypt
+{
 void Init(bool is_login, uint8_t seed[4]);
 void Encrypt(bool is_login, uint8_t *src, uint8_t *dest, int size);
 void Decrypt(uint8_t *src, uint8_t *dest, int size);
 size_t GetPluginsCount(); // FIXME: move this out
 
-}
+} // namespace Crypt

--- a/OrionUO/Crypt/GameCrypt.cpp
+++ b/OrionUO/Crypt/GameCrypt.cpp
@@ -1,6 +1,5 @@
 // MIT License
 
-#if !USE_ORIONDLL
 #include "GameCrypt.h"
 
 CBlowfishCrypt g_BlowfishCrypt;
@@ -604,4 +603,3 @@ void CTwofishCrypt::Decrypt(const uint8_t *in, uint8_t *out, int size)
     }
     dwIndex = dwTmpIndex;
 }
-#endif

--- a/OrionUO/Crypt/LoginCrypt.cpp
+++ b/OrionUO/Crypt/LoginCrypt.cpp
@@ -1,13 +1,11 @@
 // MIT License
 
-#if !USE_ORIONDLL
-
 #include "LoginCrypt.h"
 #include "../Wisp/WispGlobal.h"
 #include "../Wisp/WispDataStream.h"
 #include "aes.h"
+#include "../Config.h"
 
-extern vector<uint8_t> g_RawData;
 CLoginCrypt g_LoginCrypt;
 
 CLoginCrypt::CLoginCrypt()
@@ -20,14 +18,10 @@ void CLoginCrypt::Init(uint8_t ps[4])
     memcpy(m_seed, ps, 4);
     const uint32_t seed = (ps[0] << 24) | (ps[1] << 16) | (ps[2] << 8) | ps[3];
 
-    Wisp::CDataReader reader(&g_RawData[0], (int)g_RawData.size());
-    reader.Move(3);
-    const int len = reader.ReadUInt8();
-
-    m_k1 = reader.ReadUInt32LE(len);
-    m_k2 = reader.ReadUInt32LE(len);
-    m_k3 = reader.ReadUInt32LE(len);
-    const uint32_t seed_key = reader.ReadUInt16LE(len);
+    m_k1 = g_Config.Key1;
+    m_k2 = g_Config.Key2;
+    m_k3 = g_Config.Key3;
+    const uint32_t seed_key = g_Config.Seed;
 
     m_key[0] = (((~seed) ^ seed_key) << 16) | ((seed ^ 0xffffaaaa) & 0x0000ffff);
     m_key[1] = ((seed ^ 0x43210000) >> 16) | (((~seed) ^ 0xabcdffff) & 0xffff0000);
@@ -79,5 +73,3 @@ void CLoginCrypt::Encrypt_1_25_36(const uint8_t *in, uint8_t *out, int size)
                    (m_key[1] * m_key[1] * 0x4c3a1353) + 0x16ef783f;
     }
 }
-
-#endif

--- a/OrionUO/Crypt/md5.cpp
+++ b/OrionUO/Crypt/md5.cpp
@@ -1,6 +1,5 @@
 // MIT License
 
-#if !USE_ORIONDLL
 #include <memory.h>
 #include <string.h>
 #include "md5.h"
@@ -310,4 +309,3 @@ void MD5Crypt::finish(md5_state *pms, unsigned char digest[16])
         digest[i] = (unsigned char)(pms->abcd[i >> 2] >> ((i & 3) << 3));
     }
 }
-#endif

--- a/OrionUO/Crypt/twofish.cpp
+++ b/OrionUO/Crypt/twofish.cpp
@@ -1,5 +1,3 @@
-#if !USE_ORIONDLL
-
 /***************************************************************************
 	TWOFISH2.C  -- Optimized C API calls for TWOFISH AES submission
 
@@ -1335,4 +1333,3 @@ u32 TwofishCodeSize(void)
     return x - TwofishCodeStart();
 };
 #endif
-#endif // USE_ORIONDLL

--- a/OrionUO/GUI/GUIBulletinBoardObject.cpp
+++ b/OrionUO/GUI/GUIBulletinBoardObject.cpp
@@ -1,6 +1,9 @@
 ﻿// MIT License
 // Copyright (C) August 2016 Hotride
 
+#include "GUIBulletinBoardObject.h"
+#include "../Config.h"
+
 CGUIBulletinBoardObject::CGUIBulletinBoardObject(int serial, int x, int y, const wstring &text)
     : CBaseGUI(GOT_BB_OBJECT, serial, 0, 0, x, y)
     , Text(text)
@@ -8,7 +11,7 @@ CGUIBulletinBoardObject::CGUIBulletinBoardObject(int serial, int x, int y, const
     DEBUG_TRACE_FUNCTION;
     MoveOnDrag = true;
 
-    if (g_PacketManager.GetClientVersion() >= CV_305D)
+    if (g_Config.ClientVersion >= CV_305D)
     {
         g_FontManager.GenerateW(1, m_Texture, text, 0);
     }

--- a/OrionUO/GUI/GUIGenericText.cpp
+++ b/OrionUO/GUI/GUIGenericText.cpp
@@ -22,11 +22,5 @@ void CGUIGenericText::CreateTexture(const wstring &str)
         flags |= UOFONT_CROPPED;
     }
 
-    CreateTextureW(
-        (uint8_t)(g_PacketManager.GetClientVersion() >= CV_305D),
-        str,
-        30,
-        MaxWidth,
-        TS_LEFT,
-        flags);
+    CreateTextureW((uint8_t)(g_Config.ClientVersion >= CV_305D), str, 30, MaxWidth, TS_LEFT, flags);
 }

--- a/OrionUO/GUI/GUIGenericText.cpp
+++ b/OrionUO/GUI/GUIGenericText.cpp
@@ -1,6 +1,9 @@
 ﻿// MIT License
 // Copyright (C) August 2016 Hotride
 
+#include "GUIGenericText.h"
+#include "../Config.h"
+
 CGUIGenericText::CGUIGenericText(int index, uint16_t color, int x, int y, int maxWidth)
     : CGUIText(color, x, y)
     , TextID(index)

--- a/OrionUO/GUI/GUIGenericTextEntry.cpp
+++ b/OrionUO/GUI/GUIGenericTextEntry.cpp
@@ -1,6 +1,9 @@
 ﻿// MIT License
 // Copyright (C) August 2016 Hotride
 
+#include "GUIGenericTextEntry.h"
+#include "../Config.h"
+
 CGUIGenericTextEntry::CGUIGenericTextEntry(
     int serial, int index, uint16_t color, int x, int y, int maxWidth, int maxLength)
     : CGUITextEntry(
@@ -12,7 +15,7 @@ CGUIGenericTextEntry::CGUIGenericTextEntry(
           y,
           maxWidth,
           true,
-          (uint8_t)(g_PacketManager.GetClientVersion() >= CV_305D),
+          (uint8_t)(g_Config.ClientVersion >= CV_305D),
           TS_LEFT,
           UOFONT_BLACK_BORDER,
           maxLength)

--- a/OrionUO/GameObjects/GameItem.cpp
+++ b/OrionUO/GameObjects/GameItem.cpp
@@ -752,7 +752,7 @@ void CGameItem::LoadMulti(bool dropAlpha)
     {
         int itemOffset = sizeof(MULTI_BLOCK);
 
-        if (g_PacketManager.GetClientVersion() >= CV_7090)
+        if (g_Config.ClientVersion >= CV_7090)
         {
             itemOffset = sizeof(MULTI_BLOCK_NEW);
         }

--- a/OrionUO/GameObjects/GameItem.cpp
+++ b/OrionUO/GameObjects/GameItem.cpp
@@ -1,6 +1,9 @@
 // MIT License
 // Copyright (C) August 2016 Hotride
 
+#include "GameItem.h"
+#include "Config.h"
+
 CGameItem::CGameItem(int serial)
     : CGameObject(serial)
 {

--- a/OrionUO/GameObjects/GameObject.cpp
+++ b/OrionUO/GameObjects/GameObject.cpp
@@ -377,7 +377,7 @@ void CGameObject::ClearNotOpenedItems()
 bool CGameObject::Poisoned()
 {
     DEBUG_TRACE_FUNCTION;
-    if (g_PacketManager.GetClientVersion() >= CV_7000)
+    if (g_Config.ClientVersion >= CV_7000)
     {
         return SA_Poisoned;
     }
@@ -387,7 +387,7 @@ bool CGameObject::Poisoned()
 bool CGameObject::Flying()
 {
     DEBUG_TRACE_FUNCTION;
-    if (g_PacketManager.GetClientVersion() >= CV_7000)
+    if (g_Config.ClientVersion >= CV_7000)
     {
         return (m_Flags & 0x04) != 0;
     }
@@ -662,7 +662,7 @@ CGameItem *CGameObject::FindLayer(int layer)
 bool CGameObject::Caller()
 {
     DEBUG_TRACE_FUNCTION;
-    if (g_PacketManager.GetClientVersion() >= CV_7000)
+    if (g_Config.ClientVersion >= CV_7000)
     {
         return pvpCaller;
     }

--- a/OrionUO/GameObjects/GameObject.cpp
+++ b/OrionUO/GameObjects/GameObject.cpp
@@ -1,7 +1,9 @@
 // MIT License
 // Copyright (C) August 2016 Hotride
 
+#include "GameObject.h"
 #include <SDL_timer.h>
+#include "Config.h"
 
 CGameObject::CGameObject(int serial)
     : CRenderStaticObject(ROT_GAME_OBJECT, serial, 0, 0, 0, 0, 0)

--- a/OrionUO/Globals.cpp
+++ b/OrionUO/Globals.cpp
@@ -4,12 +4,9 @@
 bool g_AltPressed = false;
 bool g_CtrlPressed = false;
 bool g_ShiftPressed = false;
-
 bool g_MovingFromMouse = false;
 bool g_AutoMoving = false;
-bool g_TheAbyss = false;
 bool g_AbyssPacket03First = true;
-bool g_Asmut = false;
 
 int g_LandObjectsCount = 0;
 int g_StaticsObjectsCount = 0;
@@ -40,7 +37,10 @@ GAME_STATE g_GameState = GS_MAIN;
 
 CGLTexture g_TextureGumpState[2];
 
-Wisp::CSize g_MapSize[MAX_MAPS_COUNT];
+Wisp::CSize g_MapSize[MAX_MAPS_COUNT] = {
+    // Felucca      Trammel         Ilshenar        Malas           Tokuno          TerMur
+    { 7168, 4096 }, { 7168, 4096 }, { 2304, 1600 }, { 2560, 2048 }, { 1448, 1448 }, { 1280, 4096 },
+};
 Wisp::CSize g_MapBlockSize[MAX_MAPS_COUNT];
 
 int g_MultiIndexCount = 0;

--- a/OrionUO/Globals.h
+++ b/OrionUO/Globals.h
@@ -39,9 +39,7 @@ extern bool g_CtrlPressed;
 extern bool g_ShiftPressed;
 extern bool g_MovingFromMouse;
 extern bool g_AutoMoving;
-extern bool g_TheAbyss;
 extern bool g_AbyssPacket03First;
-extern bool g_Asmut;
 
 bool CanBeDraggedByOffset(const Wisp::CPoint2Di &point);
 void TileOffsetOnMonitorToXY(int &ofsX, int &ofsY, int &x, int &y);

--- a/OrionUO/Gumps/GumpBulletinBoardItem.cpp
+++ b/OrionUO/Gumps/GumpBulletinBoardItem.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) August 2016 Hotride
 
 #include "GumpBulletinBoardItem.h"
+#include "../Config.h"
 
 enum
 {
@@ -33,7 +34,7 @@ CGumpBulletinBoardItem::CGumpBulletinBoardItem(
     ID = id;
     m_MinHeight = 200;
 
-    bool useUnicode = (g_PacketManager.GetClientVersion() >= CV_305D);
+    bool useUnicode = (g_Config.ClientVersion >= CV_305D);
     int unicodeFontIndex = 1;
     int unicodeHeightOffset = 0;
     uint16_t textColor = 0x0386;

--- a/OrionUO/Gumps/GumpCombatBook.cpp
+++ b/OrionUO/Gumps/GumpCombatBook.cpp
@@ -1,15 +1,18 @@
 // MIT License
 // Copyright (C) December 2016 Hotride
 
+#include "GumpCombatBook.h"
+#include "../Config.h"
+
 CGumpCombatBook::CGumpCombatBook(int x, int y)
     : CGump(GT_COMBAT_BOOK, 0, x, y)
 {
     DEBUG_TRACE_FUNCTION;
     Draw2Page = 1;
 
-    if (g_PacketManager.GetClientVersion() < CV_7000)
+    if (g_Config.ClientVersion < CV_7000)
     {
-        if (g_PacketManager.GetClientVersion() >= CV_500A)
+        if (g_Config.ClientVersion >= CV_500A)
         {
             AbilityCount = 29;
         }

--- a/OrionUO/Gumps/GumpOptions.cpp
+++ b/OrionUO/Gumps/GumpOptions.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) August 2016 Hotride
 
 #include "GumpOptions.h"
+#include "../Config.h"
 
 #if USE_WISP
 #define KeyName(x) s_HotkeyText[x & 0xFF]

--- a/OrionUO/Gumps/GumpOptions.cpp
+++ b/OrionUO/Gumps/GumpOptions.cpp
@@ -2644,7 +2644,7 @@ void CGumpOptions::DrawPage7()
     checkbox->Checked = g_OptionsConfig.ColoredLighting;
     checkbox->SetTextParameters(0, L"Colored Lighting", g_OptionsTextColor);
 
-    if (g_PacketManager.GetClientVersion() >= CV_6000)
+    if (g_Config.ClientVersion >= CV_6000)
     {
         Add(new CGUIButton(ID_GO_P7_GUILD_MESSAGE_COLOR, 0x00D4, 0x00D4, 0x00D4, 354, 204));
 
@@ -4461,7 +4461,7 @@ void CGumpOptions::ApplyPageChanges()
             g_OptionsConfig.GameWindowHeight = curY;
             g_ConfigManager.GameWindowHeight = curY;
 
-            if (g_PacketManager.GetClientVersion() >= CV_200)
+            if (g_Config.ClientVersion >= CV_200)
             {
                 CPacketGameWindowSize().Send();
             }

--- a/OrionUO/Gumps/GumpPaperdoll.cpp
+++ b/OrionUO/Gumps/GumpPaperdoll.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) August 2016 Hotride
 
 #include "GumpPaperdoll.h"
+#include "../Config.h"
 
 enum
 {
@@ -67,7 +68,7 @@ CGumpPaperdoll::CGumpPaperdoll(uint32_t serial, short x, short y, bool minimized
         Add(new CGUIButton(ID_GP_BUTTON_OPTIONS, 0x07D6, 0x07D8, 0x07D7, 185, 71));
         Add(new CGUIButton(ID_GP_BUTTON_LOGOUT, 0x07D9, 0x07DB, 0x07DA, 185, 98));
 
-        if (g_PacketManager.GetClientVersion() >= CV_500A)
+        if (g_Config.ClientVersion >= CV_500A)
         {
             Add(new CGUIButton(ID_GP_BUTTON_JOURNAL_OR_QUESTS, 0x57B5, 0x57B6, 0x57B7, 185, 125));
         }
@@ -78,7 +79,7 @@ CGumpPaperdoll::CGumpPaperdoll(uint32_t serial, short x, short y, bool minimized
 
         Add(new CGUIButton(ID_GP_BUTTON_SKILLS, 0x07DF, 0x07E1, 0x07E0, 185, 152));
 
-        if (g_PacketManager.GetClientVersion() >= CV_500A)
+        if (g_Config.ClientVersion >= CV_500A)
         {
             Add(new CGUIButton(ID_GP_BUTTON_CHAT_OR_GUILD, 0x57B2, 0x57B3, 0x57B4, 185, 179));
         }
@@ -114,7 +115,7 @@ CGumpPaperdoll::CGumpPaperdoll(uint32_t serial, short x, short y, bool minimized
         {
             Add(new CGUIButton(ID_GP_COMBAT_BOOK, 0x2B34, 0x2B34, 0x2B34, 156, 200));
 
-            if (g_PacketManager.GetClientVersion() >= CV_7000)
+            if (g_Config.ClientVersion >= CV_7000)
             {
                 Add(new CGUIButton(ID_GP_RACIAL_ABILITIES_BOOK, 0x2B28, 0x2B28, 0x2B28, 23, 200));
                 profileX += SCROLLS_STEP;
@@ -198,7 +199,7 @@ void CGumpPaperdoll::InitToolTip()
             }
             case ID_GP_BUTTON_JOURNAL_OR_QUESTS:
             {
-                if (g_PacketManager.GetClientVersion() >= CV_500A)
+                if (g_Config.ClientVersion >= CV_500A)
                 {
                     g_ToolTip.Set(L"Open the quests gump");
                 }
@@ -216,7 +217,7 @@ void CGumpPaperdoll::InitToolTip()
             }
             case ID_GP_BUTTON_CHAT_OR_GUILD:
             {
-                if (g_PacketManager.GetClientVersion() >= CV_500A)
+                if (g_Config.ClientVersion >= CV_500A)
                 {
                     g_ToolTip.Set(L"Open the guild gump");
                 }
@@ -862,7 +863,7 @@ void CGumpPaperdoll::GUMP_BUTTON_EVENT_C
         }
         case ID_GP_BUTTON_JOURNAL_OR_QUESTS: //Paperdoll button Journal
         {
-            if (g_PacketManager.GetClientVersion() >= CV_500A)
+            if (g_Config.ClientVersion >= CV_500A)
             {
                 CPacketQuestMenuRequest().Send();
             }
@@ -879,7 +880,7 @@ void CGumpPaperdoll::GUMP_BUTTON_EVENT_C
         }
         case ID_GP_BUTTON_CHAT_OR_GUILD: //Paperdoll button Chat
         {
-            if (g_PacketManager.GetClientVersion() >= CV_500A)
+            if (g_Config.ClientVersion >= CV_500A)
             {
                 CPacketGuildMenuRequest().Send();
             }

--- a/OrionUO/Gumps/GumpScreenCharacterList.cpp
+++ b/OrionUO/Gumps/GumpScreenCharacterList.cpp
@@ -3,6 +3,7 @@
 
 #include "GumpScreenCharacterList.h"
 #include <SDL_timer.h>
+#include "../Config.h"
 
 enum
 {
@@ -35,13 +36,13 @@ void CGumpScreenCharacterList::UpdateContent()
     Clear();
 
     int count = g_CharacterList.Count;
-    bool testField = (g_PacketManager.GetClientVersion() >= CV_305D);
+    bool testField = (g_Config.ClientVersion >= CV_305D);
     int posInList = 0;
     int yOffset = 150;
     int yBonus = 0;
     int listTitleY = 106;
 
-    if (g_PacketManager.GetClientVersion() >= CV_6040)
+    if (g_Config.ClientVersion >= CV_6040)
     {
         listTitleY = 96;
         yOffset = 125;
@@ -147,7 +148,7 @@ void CGumpScreenCharacterList::InitToolTip()
 
     if (id >= ID_CS_CHARACTERS)
     {
-        bool testField = (g_PacketManager.GetClientVersion() >= CV_305D);
+        bool testField = (g_Config.ClientVersion >= CV_305D);
 
         for (int i = 0; i < g_CharacterList.Count; i++)
         {

--- a/OrionUO/Gumps/GumpScreenCreateCharacter.cpp
+++ b/OrionUO/Gumps/GumpScreenCreateCharacter.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) August 2016 Hotride
 
 #include "GumpScreenCreateCharacter.h"
+#include "../Config.h"
 
 enum
 {
@@ -433,7 +434,7 @@ void CGumpScreenCreateCharacter::UpdateContent()
 
     Add(new CGUIShader(nullptr, false));
 
-    if (g_PacketManager.GetClientVersion() < CV_4011D)
+    if (g_Config.ClientVersion < CV_4011D)
     {
         if (g_CreateCharacterManager.GetFemale())
         {
@@ -472,7 +473,7 @@ void CGumpScreenCreateCharacter::UpdateContent()
         Add(new CGUIButton(ID_CCS_HUMAN_RACE_BUTTON, 0x0702, 0x0703, 0x0704, 200, 435));
         Add(new CGUIButton(ID_CCS_ELF_RACE_BUTTON, 0x0705, 0x0706, 0x0707, 200, 455));
 
-        if (g_PacketManager.GetClientVersion() >= CV_60144)
+        if (g_Config.ClientVersion >= CV_60144)
         {
             radio = (CGUIRadio *)Add(
                 new CGUIRadio(ID_CCS_GARGOYLE_RACE_BUTTON, 0x0768, 0x0767, 0x0767, 60, 435));

--- a/OrionUO/Gumps/GumpScreenGame.cpp
+++ b/OrionUO/Gumps/GumpScreenGame.cpp
@@ -268,7 +268,7 @@ void CGumpScreenGame::OnLeftMouseButtonUp()
             g_ConfigManager.GameWindowHeight = screenY;
         }
 
-        if (g_PacketManager.GetClientVersion() >= CV_200)
+        if (g_Config.ClientVersion >= CV_200)
         {
             CPacketGameWindowSize().Send();
         }

--- a/OrionUO/Gumps/GumpScreenGame.cpp
+++ b/OrionUO/Gumps/GumpScreenGame.cpp
@@ -1,6 +1,9 @@
 // MIT License
 // Copyright (C) August 2016 Hotride
 
+#include "GumpScreenGame.h"
+#include "../Config.h"
+
 CGumpScreenGame::CGumpScreenGame()
     : CGump(GT_NONE, 0, 0, 0)
 {

--- a/OrionUO/Gumps/GumpScreenMain.cpp
+++ b/OrionUO/Gumps/GumpScreenMain.cpp
@@ -3,6 +3,7 @@
 
 #include "GumpScreenMain.h"
 #include "GitRevision.h"
+#include "../Config.h"
 
 enum
 {
@@ -68,7 +69,7 @@ void CGumpScreenMain::UpdateContent()
 
     Add(new CGUIGumppic(0x157C, 0, 0));
 
-    if (g_PacketManager.GetClientVersion() >= CV_500A)
+    if (g_Config.ClientVersion >= CV_500A)
     {
         Add(new CGUIGumppic(0x2329, 0, 0));
     }
@@ -76,7 +77,7 @@ void CGumpScreenMain::UpdateContent()
     Add(new CGUIGumppic(0x15A0, 0, 4));
     Add(new CGUIResizepic(0, 0x13BE, 128, 288, 451, 157));
 
-    if (g_PacketManager.GetClientVersion() < CV_500A)
+    if (g_Config.ClientVersion < CV_500A)
     {
         Add(new CGUIGumppic(0x058A, 286, 45));
     }
@@ -105,7 +106,7 @@ void CGumpScreenMain::UpdateContent()
     text->CreateTextureA(2, "Password");
 
     text = (CGUIText *)Add(new CGUIText(0x034E, 286, 455));
-    text->CreateTextureA(9, string("UO Version " + g_Orion.ClientVersionText + "."));
+    text->CreateTextureA(9, string("UO Version " + g_Config.ClientVersionString + "."));
 
     text = (CGUIText *)Add(new CGUIText(0x034E, 286, 467));
     text->CreateTextureA(9, string("Orion beta v") + RC_PRODUCE_VERSION_STR);

--- a/OrionUO/Gumps/GumpScreenSelectProfession.cpp
+++ b/OrionUO/Gumps/GumpScreenSelectProfession.cpp
@@ -54,7 +54,7 @@ void CGumpScreenSelectProfession::UpdateContent()
         return;
     }
 
-    if (g_PacketManager.GetClientVersion() >= CV_308Z)
+    if (g_Config.ClientVersion >= CV_308Z)
     {
         UpdateContentNew();
     }
@@ -438,7 +438,7 @@ void CGumpScreenSelectProfession::UpdateContentNew()
             int skillsCount = 3;
             int skillStep = 80;
 
-            if (g_PacketManager.GetClientVersion() >= CV_70160)
+            if (g_Config.ClientVersion >= CV_70160)
             {
                 yPtr -= 12;
                 skillStep = 70;
@@ -575,7 +575,7 @@ void CGumpScreenSelectProfession::GUMP_BUTTON_EVENT_C
     }
     else if (serial == ID_SPS_ARROW_PREV) //< button
     {
-        if (g_PacketManager.GetClientVersion() >= CV_308Z &&
+        if (g_Config.ClientVersion >= CV_308Z &&
             g_ProfessionManager.Selected->Type == PT_PROFESSION &&
             g_ProfessionManager.Selected->DescriptionIndex == -1 /*Advanced*/)
         {
@@ -600,7 +600,7 @@ void CGumpScreenSelectProfession::GUMP_BUTTON_EVENT_C
             {
                 int skillsCount = 3;
 
-                if (g_PacketManager.GetClientVersion() >= CV_70160)
+                if (g_Config.ClientVersion >= CV_70160)
                 {
                     skillsCount++;
                 }
@@ -654,7 +654,7 @@ void CGumpScreenSelectProfession::GUMP_BUTTON_EVENT_C
                 g_ProfessionManager.Selected = child;
                 g_SelectProfessionScreen.SetSkillSelection(0);
 
-                if (g_PacketManager.GetClientVersion() >= CV_308Z && child->Type == PT_PROFESSION &&
+                if (g_Config.ClientVersion >= CV_308Z && child->Type == PT_PROFESSION &&
                     child->DescriptionIndex != -1)
                 {
                     g_SelectProfessionScreen.CreateSmoothAction(
@@ -684,7 +684,7 @@ void CGumpScreenSelectProfession::GUMP_BUTTON_EVENT_C
         {
             int skillsCount = 3;
 
-            if (g_PacketManager.GetClientVersion() >= CV_70160)
+            if (g_Config.ClientVersion >= CV_70160)
             {
                 skillsCount++;
             }
@@ -713,7 +713,7 @@ void CGumpScreenSelectProfession::GUMP_SLIDER_MOVE_EVENT_C
     DEBUG_TRACE_FUNCTION;
     int skillsCount = 3;
 
-    if (g_PacketManager.GetClientVersion() >= CV_70160)
+    if (g_Config.ClientVersion >= CV_70160)
     {
         skillsCount++;
     }
@@ -721,9 +721,9 @@ void CGumpScreenSelectProfession::GUMP_SLIDER_MOVE_EVENT_C
     //Stats
     if (serial >= ID_SPS_STATS_SPHERE && (int)serial < ID_SPS_STATS_SPHERE + skillsCount)
     {
-        if (g_PacketManager.GetClientVersion() >= CV_308Z)
+        if (g_Config.ClientVersion >= CV_308Z)
         {
-            if (g_PacketManager.GetClientVersion() >= CV_70160)
+            if (g_Config.ClientVersion >= CV_70160)
             {
                 ShuffleStats(serial - ID_SPS_STATS_SPHERE, 90, 60);
             }
@@ -868,7 +868,7 @@ void CGumpScreenSelectProfession::ShuffleSkills(int id)
     int skillsCount = 3;
     bool use4Skill = false;
 
-    if (g_PacketManager.GetClientVersion() >= CV_70160)
+    if (g_Config.ClientVersion >= CV_70160)
     {
         use4Skill = true;
         skillsCount++;

--- a/OrionUO/Gumps/GumpScreenSelectProfession.cpp
+++ b/OrionUO/Gumps/GumpScreenSelectProfession.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) August 2016 Hotride
 
 #include "GumpScreenSelectProfession.h"
+#include "../Config.h"
 
 enum
 {

--- a/OrionUO/Gumps/GumpScreenSelectTown.cpp
+++ b/OrionUO/Gumps/GumpScreenSelectTown.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) August 2016 Hotride
 
 #include "GumpScreenSelectTown.h"
+#include "../Config.h"
 
 enum
 {
@@ -64,7 +65,7 @@ void CGumpScreenSelectTown::UpdateContent()
     Add(new CGUIGumppic(0x157C, 0, 0));
     Add(new CGUIGumppic(0x15A0, 0, 4));
 
-    if (g_PacketManager.GetClientVersion() >= CV_70130)
+    if (g_Config.ClientVersion >= CV_70130)
     {
         Add(new CGUIGumppic(0x15D9 + map, 62, 54));
         Add(new CGUIGumppic(0x15DF, 57, 49));
@@ -100,7 +101,7 @@ void CGumpScreenSelectTown::UpdateContent()
 
     for (int i = 0; i < (int)g_CityList.CityCount(); i++)
     {
-        if (g_PacketManager.GetClientVersion() >= CV_70130)
+        if (g_Config.ClientVersion >= CV_70130)
         {
             city = g_CityList.GetCity((uint32_t)i);
         }

--- a/OrionUO/Gumps/GumpScreenServer.cpp
+++ b/OrionUO/Gumps/GumpScreenServer.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) August 2016 Hotride
 
 #include "GumpScreenServer.h"
+#include "../Config.h"
 
 enum
 {
@@ -46,14 +47,14 @@ void CGumpScreenServer::UpdateContent()
     CCliloc *cliloc = g_ClilocManager.Cliloc(g_Language);
 
     uint16_t textColor = 0x0481;
-    if (g_PacketManager.GetClientVersion() >= CV_500A)
+    if (g_Config.ClientVersion >= CV_500A)
     {
         textColor = 0xFFFF;
     }
 
     CGUIText *text = new CGUIText(textColor, 155, 70);
 
-    if (g_PacketManager.GetClientVersion() >= CV_500A)
+    if (g_Config.ClientVersion >= CV_500A)
     {
         text->CreateTextureW(0, cliloc->GetW(1044579, false, "Select which shard to play on:"));
     }
@@ -66,7 +67,7 @@ void CGumpScreenServer::UpdateContent()
 
     text = new CGUIText(textColor, 400, 70);
 
-    if (g_PacketManager.GetClientVersion() >= CV_500A)
+    if (g_Config.ClientVersion >= CV_500A)
     {
         text->CreateTextureW(0, cliloc->GetW(1044577, false, "Latency:"));
     }
@@ -79,7 +80,7 @@ void CGumpScreenServer::UpdateContent()
 
     text = new CGUIText(textColor, 470, 70);
 
-    if (g_PacketManager.GetClientVersion() >= CV_500A)
+    if (g_Config.ClientVersion >= CV_500A)
     {
         text->CreateTextureW(0, cliloc->GetW(1044578, false, "Packet Loss:"));
     }
@@ -98,7 +99,7 @@ void CGumpScreenServer::UpdateContent()
 
     text = new CGUIText(textColor, 153, 368);
 
-    if (g_PacketManager.GetClientVersion() >= CV_500A)
+    if (g_Config.ClientVersion >= CV_500A)
     {
         text->CreateTextureW(0, cliloc->GetW(1044580, false, "Sort by:"));
     }

--- a/OrionUO/Gumps/GumpSecureTrading.cpp
+++ b/OrionUO/Gumps/GumpSecureTrading.cpp
@@ -1,6 +1,9 @@
 // MIT License
 // Copyright (C) August 2016 Hotride
 
+#include "GumpSecureTrading.h"
+#include "../Config.h"
+
 CGumpSecureTrading::CGumpSecureTrading(uint32_t serial, short x, short y, uint32_t id, uint32_t id2)
     : CGump(GT_TRADE, serial, x, y)
     , ID2(id2)
@@ -93,7 +96,7 @@ void CGumpSecureTrading::UpdateContent()
     {
         Add(new CGUIGumppic(0x0866, 0, 0)); //Trade Gump
 
-        if (g_PacketManager.GetClientVersion() < CV_500A)
+        if (g_Config.ClientVersion < CV_500A)
         {
             Add(new CGUIColoredPolygone(0, 0, 45, 90, 110, 60, 0xFF000001));
 

--- a/OrionUO/Gumps/GumpSpellbook.cpp
+++ b/OrionUO/Gumps/GumpSpellbook.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) September 2016 Hotride
 
 #include "GumpSpellbook.h"
+#include "../Config.h"
 
 enum
 {
@@ -1067,7 +1068,7 @@ bool CGumpSpellbook::OnLeftMouseButtonDoubleClick()
 
                 spellIndex += ((int)BookType * 100);
 
-                if (g_PacketManager.GetClientVersion() < CV_308Z)
+                if (g_Config.ClientVersion < CV_308Z)
                 {
                     g_Orion.CastSpellFromBook(spellIndex, Serial);
                 }

--- a/OrionUO/Gumps/GumpStatusbar.cpp
+++ b/OrionUO/Gumps/GumpStatusbar.cpp
@@ -3,6 +3,7 @@
 
 #include "GumpStatusbar.h"
 #include <SDL_rect.h>
+#include "../Config.h"
 
 int CGumpStatusbar::m_StatusbarDefaultWidth = 154;
 int CGumpStatusbar::m_StatusbarDefaultHeight = 59;
@@ -120,8 +121,8 @@ CGumpStatusbar::CGumpStatusbar(uint32_t serial, short x, short y, bool minimized
 CGumpStatusbar::~CGumpStatusbar()
 {
     DEBUG_TRACE_FUNCTION;
-    if (g_ConnectionManager.Connected() && g_PacketManager.GetClientVersion() >= CV_200 &&
-        g_World != nullptr && g_World->FindWorldObject(Serial) != nullptr)
+    if (g_ConnectionManager.Connected() && g_Config.ClientVersion >= CV_200 && g_World != nullptr &&
+        g_World->FindWorldObject(Serial) != nullptr)
     {
         CPacketCloseStatusbarGump(Serial).Send();
     }
@@ -539,8 +540,7 @@ void CGumpStatusbar::UpdateContent()
         {
             SDL_Point p = { 0, 0 };
 
-            if (g_PacketManager.GetClientVersion() >= CV_308D &&
-                !g_ConfigManager.GetOldStyleStatusbar())
+            if (g_Config.ClientVersion >= CV_308D && !g_ConfigManager.GetOldStyleStatusbar())
             {
                 Add(new CGUIGumppic(0x2A6C, 0, 0));
             }
@@ -552,8 +552,7 @@ void CGumpStatusbar::UpdateContent()
             }
             int xOffset = 0;
             // Client version specifics drawing
-            if (g_PacketManager.GetClientVersion() >= CV_308Z &&
-                !g_ConfigManager.GetOldStyleStatusbar())
+            if (g_Config.ClientVersion >= CV_308Z && !g_ConfigManager.GetOldStyleStatusbar())
             {
                 p.x = 389;
                 p.y = 152;
@@ -565,7 +564,7 @@ void CGumpStatusbar::UpdateContent()
                     text->CreateTextureA(1, g_Player->GetName(), 320, TS_CENTER);
                 }
 
-                if (g_PacketManager.GetClientVersion() >= CV_5020)
+                if (g_Config.ClientVersion >= CV_5020)
                 {
                     Add(new CGUIButton(ID_GSB_BUFF_GUMP, 0x7538, 0x7538, 0x7538, 40, 50));
                 }
@@ -902,14 +901,14 @@ void CGumpStatusbar::UpdateContent()
 
                 if (!g_ConfigManager.GetOldStyleStatusbar())
                 {
-                    if (g_PacketManager.GetClientVersion() == CV_308D)
+                    if (g_Config.ClientVersion == CV_308D)
                     {
                         text = (CGUIText *)Add(new CGUIText(0x0386, 171, 124));
                         text->CreateTextureA(1, std::to_string(g_Player->StatsCap));
 
                         Add(new CGUIHitBox(ID_GSB_TEXT_MAX_STATS, 171, 124, 34, 12));
                     }
-                    else if (g_PacketManager.GetClientVersion() == CV_308J)
+                    else if (g_Config.ClientVersion == CV_308J)
                     {
                         text = (CGUIText *)Add(new CGUIText(0x0386, 180, 131));
                         text->CreateTextureA(1, std::to_string(g_Player->StatsCap));

--- a/OrionUO/IndexObject.cpp
+++ b/OrionUO/IndexObject.cpp
@@ -1,6 +1,9 @@
 ﻿// MIT License
 // Copyright (C) August 2016 Hotride
 
+#include "IndexObject.h"
+#include "Config.h"
+
 CIndexObject::CIndexObject()
 {
 }
@@ -106,7 +109,7 @@ void CIndexObject::ReadIndexFile(size_t address, BASE_IDX_BLOCK *ptr, const uint
 void CIndexMulti::ReadIndexFile(size_t address, BASE_IDX_BLOCK *ptr, const uint16_t id)
 {
     CIndexObject::ReadIndexFile(address, ptr, id);
-    if (g_PacketManager.GetClientVersion() >= CV_7090)
+    if (g_Config.ClientVersion >= CV_7090)
     {
         Count = (uint16_t)(DataSize / sizeof(MULTI_BLOCK_NEW));
     }

--- a/OrionUO/Managers/AnimationManager.cpp
+++ b/OrionUO/Managers/AnimationManager.cpp
@@ -1,6 +1,9 @@
 // MIT License
 // Copyright (C) August 2016 Hotride
 
+#include "AnimationManager.h"
+#include "../Config.h"
+
 CAnimationManager g_AnimationManager;
 
 const int CAnimationManager::m_UsedLayers[8][USED_LAYER_COUNT] = {
@@ -296,7 +299,7 @@ void CAnimationManager::Load(uint32_t *verdata)
 void CAnimationManager::InitIndexReplaces(uint32_t *verdata)
 {
     DEBUG_TRACE_FUNCTION;
-    if (g_PacketManager.GetClientVersion() >= CV_500A)
+    if (g_Config.ClientVersion >= CV_500A)
     {
         static const string typeNames[5] = {
             "monster", "sea_monster", "animal", "human", "equipment"
@@ -364,7 +367,7 @@ void CAnimationManager::InitIndexReplaces(uint32_t *verdata)
         }
     }
 
-    if (g_PacketManager.GetClientVersion() < CV_305D)
+    if (g_Config.ClientVersion < CV_305D)
     { //CV_204C
         return;
     }
@@ -584,7 +587,7 @@ void CAnimationManager::InitIndexReplaces(uint32_t *verdata)
                     CIndexAnimation &dataIndex = m_DataIndex[index];
                     dataIndex.MountedHeightOffset = mountedHeightOffset;
 
-                    if (g_PacketManager.GetClientVersion() < CV_500A || groupType == AGT_UNKNOWN)
+                    if (g_Config.ClientVersion < CV_500A || groupType == AGT_UNKNOWN)
                     {
                         if (realAnimID >= 200)
                         {

--- a/OrionUO/Managers/ConfigManager.cpp
+++ b/OrionUO/Managers/ConfigManager.cpp
@@ -1,7 +1,9 @@
 // MIT License
 // Copyright (C) August 2016 Hotride
 
-#include "FileSystem.h"
+#include "ConfigManager.h"
+#include "../FileSystem.h"
+#include "../Config.h"
 
 CConfigManager g_ConfigManager;
 CConfigManager g_OptionsConfig;
@@ -317,7 +319,7 @@ void CConfigManager::Init()
     GameWindowX = 0;
     GameWindowY = 0;
 
-    if (g_PacketManager.GetClientVersion() >= CV_70331)
+    if (g_Config.ClientVersion >= CV_70331)
     {
         g_MaxViewRange = MAX_VIEW_RANGE_NEW;
     }

--- a/OrionUO/Managers/ConnectionManager.h
+++ b/OrionUO/Managers/ConnectionManager.h
@@ -3,18 +3,6 @@
 
 #pragma once
 
-#if defined(ORION_LINUX)
-#define __cdecl
-#endif
-
-typedef void __cdecl NETWORK_INIT_TYPE(bool, uint8_t *);
-typedef void __cdecl NETWORK_ACTION_TYPE(bool, uint8_t *, uint8_t *, int);
-typedef void __cdecl NETWORK_POST_ACTION_TYPE(uint8_t *, uint8_t *, int);
-
-extern NETWORK_INIT_TYPE *g_NetworkInit;
-extern NETWORK_ACTION_TYPE *g_NetworkAction;
-extern NETWORK_POST_ACTION_TYPE *g_NetworkPostAction;
-
 class CConnectionManager
 {
 protected:

--- a/OrionUO/Managers/FileManager.cpp
+++ b/OrionUO/Managers/FileManager.cpp
@@ -69,9 +69,9 @@ CFileManager::~CFileManager()
 bool CFileManager::Load()
 {
     DEBUG_TRACE_FUNCTION;
-    LOG("Client Verison: %d\n", g_PacketManager.GetClientVersion());
+    LOG("Client Verison: %d\n", g_Config.ClientVersion);
 
-    if (g_PacketManager.GetClientVersion() >= CV_7000 && LoadUOPFile(m_MainMisc, "MainMisc.uop"))
+    if (g_Config.ClientVersion >= CV_7000 && LoadUOPFile(m_MainMisc, "MainMisc.uop"))
     {
         return LoadWithUOP();
     }
@@ -193,9 +193,9 @@ bool CFileManager::Load()
         }
     }
 
-    if (UseVerdata && !m_VerdataMul.Load(g_App.UOFilesPath("verdata.mul")))
+    if (g_Config.UseVerdata && !m_VerdataMul.Load(g_App.UOFilesPath("verdata.mul")))
     {
-        UseVerdata = false;
+        g_Config.UseVerdata = false;
     }
 
     return true;
@@ -359,9 +359,9 @@ bool CFileManager::LoadWithUOP()
         }
     }
 
-    if (UseVerdata && !m_VerdataMul.Load(g_App.UOFilesPath("verdata.mul")))
+    if (g_Config.UseVerdata && !m_VerdataMul.Load(g_App.UOFilesPath("verdata.mul")))
     {
-        UseVerdata = false;
+        g_Config.UseVerdata = false;
     }
 
     return true;

--- a/OrionUO/Managers/FileManager.cpp
+++ b/OrionUO/Managers/FileManager.cpp
@@ -1,7 +1,9 @@
 // MIT License
 // Copyright (C) August 2016 Hotride
 
-#include "FileSystem.h"
+#include "FileManager.h"
+#include "../FileSystem.h"
+#include "../Config.h"
 
 #define MINIZ_IMPLEMENTATION
 #include <miniz.h>

--- a/OrionUO/Managers/FileManager.h
+++ b/OrionUO/Managers/FileManager.h
@@ -50,7 +50,6 @@ public:
 class CFileManager : public Wisp::CDataReader
 {
 public:
-    bool UseVerdata = false;
     bool UseUOPGumps = false;
     int UnicodeFontsCount = 0;
 

--- a/OrionUO/Managers/MacroManager.cpp
+++ b/OrionUO/Managers/MacroManager.cpp
@@ -820,7 +820,7 @@ MACRO_RETURN_CODE CMacroManager::Process(CMacroObject *macro)
                         break;
                 }
 
-                if (g_PacketManager.GetClientVersion() >= CV_500A)
+                if (g_Config.ClientVersion >= CV_500A)
                 {
                     CPacketUnicodeSpeechRequest(
                         ToWString(mos->m_String).c_str(),
@@ -1251,7 +1251,7 @@ MACRO_RETURN_CODE CMacroManager::Process(CMacroObject *macro)
         case MC_BANDAGE_TARGET:
         {
             //На самом деле с 5.0.4a
-            if (g_PacketManager.GetClientVersion() < CV_5020)
+            if (g_Config.ClientVersion < CV_5020)
             {
                 if (WaitingBandageTarget)
                 {

--- a/OrionUO/Managers/MacroManager.cpp
+++ b/OrionUO/Managers/MacroManager.cpp
@@ -1,8 +1,10 @@
 // MIT License
 // Copyright (C) August 2016 Hotride
 
-#include "FileSystem.h"
+#include "MacroManager.h"
 #include <SDL_clipboard.h>
+#include "../FileSystem.h"
+#include "../Config.h"
 
 CMacroManager g_MacroManager;
 

--- a/OrionUO/Managers/PacketManager.cpp
+++ b/OrionUO/Managers/PacketManager.cpp
@@ -3,6 +3,7 @@
 
 #include "PacketManager.h"
 #include "../Sockets.h"
+#include "../Config.h"
 #include <miniz.h>
 
 CPacketManager g_PacketManager;
@@ -347,10 +348,9 @@ bool CPacketManager::AutoLoginNameExists(const string &name)
 #define CVPRINT(s)
 #endif //CV_PRINT!=0
 
-void CPacketManager::SetClientVersion(CLIENT_VERSION newClientVersion)
+void CPacketManager::ConfigureClientVersion(uint32_t newClientVersion)
 {
     DEBUG_TRACE_FUNCTION;
-    m_ClientVersion = newClientVersion;
 
     if (newClientVersion >= CV_500A)
     {
@@ -465,11 +465,11 @@ void CPacketManager::SetClientVersion(CLIENT_VERSION newClientVersion)
         CVPRINT("Set new length for packet 0xEF (>= 7.0.0.0)\n");
         m_Packets[0xEF].Size = 0x2000;
         /*CVPRINT("Set new length for packet 0xF0 (>= 7.0.0.0)\n");
-		m_Packets[0xF0].size = 0x2000;
-		CVPRINT("Set new length for packet 0xF1 (>= 7.0.0.0)\n");
-		m_Packets[0xF1].size = 0x2000;
-		CVPRINT("Set new length for packet 0xF2 (>= 7.0.0.0)\n");
-		m_Packets[0xF2].size = 0x2000;*/
+        m_Packets[0xF0].size = 0x2000;
+        CVPRINT("Set new length for packet 0xF1 (>= 7.0.0.0)\n");
+        m_Packets[0xF1].size = 0x2000;
+        CVPRINT("Set new length for packet 0xF2 (>= 7.0.0.0)\n");
+        m_Packets[0xF2].size = 0x2000;*/
     }
     else
     {
@@ -478,11 +478,11 @@ void CPacketManager::SetClientVersion(CLIENT_VERSION newClientVersion)
         CVPRINT("Set standart length for packet 0xEF (<= 7.0.0.0)\n");
         m_Packets[0xEF].Size = 0x15;
         /*CVPRINT("Set standart length for packet 0xF0 (<= 7.0.0.0)\n");
-		m_Packets[0xF0].size = PACKET_VARIABLE_SIZE;
-		CVPRINT("Set standart length for packet 0xF1 (<= 7.0.0.0)\n");
-		m_Packets[0xF1].size = PACKET_VARIABLE_SIZE;
-		CVPRINT("Set standart length for packet 0xF2 (<= 7.0.0.0)\n");
-		m_Packets[0xF2].size = PACKET_VARIABLE_SIZE;*/
+        m_Packets[0xF0].size = PACKET_VARIABLE_SIZE;
+        CVPRINT("Set standart length for packet 0xF1 (<= 7.0.0.0)\n");
+        m_Packets[0xF1].size = PACKET_VARIABLE_SIZE;
+        CVPRINT("Set standart length for packet 0xF2 (<= 7.0.0.0)\n");
+        m_Packets[0xF2].size = PACKET_VARIABLE_SIZE;*/
     }
 
     if (newClientVersion >= CV_7090)
@@ -496,7 +496,7 @@ void CPacketManager::SetClientVersion(CLIENT_VERSION newClientVersion)
         CVPRINT("Set new length for packet 0xF3 (>= 7.0.9.0)\n");
         m_Packets[0xF3].Size = 0x1A;
 
-        //В клиенте 7.0.8.2 уже изменено
+        // Already changed in client 7.0.8.2
         CVPRINT("Set new length for packet 0xF1 (>= 7.0.9.0)\n");
         m_Packets[0xF1].Size = 0x09;
         CVPRINT("Set new length for packet 0xF2 (>= 7.0.9.0)\n");
@@ -513,7 +513,7 @@ void CPacketManager::SetClientVersion(CLIENT_VERSION newClientVersion)
         CVPRINT("Set standart length for packet 0xF3 (<= 7.0.9.0)\n");
         m_Packets[0xF3].Size = 0x18;
 
-        //В клиенте 7.0.8.2 уже изменено
+        // Already changed in client 7.0.8.2
         CVPRINT("Set standart length for packet 0xF1 (<= 7.0.9.0)\n");
         m_Packets[0xF1].Size = PACKET_VARIABLE_SIZE;
         CVPRINT("Set standart length for packet 0xF2 (<= 7.0.9.0)\n");
@@ -548,7 +548,7 @@ void CPacketManager::SendMegaClilocRequests()
     DEBUG_TRACE_FUNCTION;
     if (g_TooltipsEnabled && !m_MegaClilocRequests.empty())
     {
-        if (m_ClientVersion >= CV_500A)
+        if (g_Config.ClientVersion >= CV_500A)
         {
             while (!m_MegaClilocRequests.empty())
             {
@@ -751,7 +751,7 @@ PACKET_HANDLER(CharacterList)
     HandleResendCharacterList();
     uint8_t locCount = ReadUInt8();
     g_CityList.Clear();
-    if (m_ClientVersion >= CV_70130)
+    if (g_Config.ClientVersion >= CV_70130)
     {
         for (int i = 0; i < locCount; i++)
         {
@@ -796,7 +796,7 @@ PACKET_HANDLER(CharacterList)
     //g_SendLogoutNotification = (bool)(g_ClientFlag & LFF_RE);
     g_PopupEnabled = (bool)(g_ClientFlag & CLF_CONTEXT_MENU);
     g_TooltipsEnabled =
-        (bool)(((g_ClientFlag & CLF_PALADIN_NECROMANCER_TOOLTIPS) != 0u) && (g_PacketManager.GetClientVersion() >= CV_308Z));
+        (bool)(((g_ClientFlag & CLF_PALADIN_NECROMANCER_TOOLTIPS) != 0u) && (g_Config.ClientVersion >= CV_308Z));
     g_PaperdollBooks = (bool)(g_ClientFlag & CLF_PALADIN_NECROMANCER_TOOLTIPS);
 
     g_CharacterListScreen.UpdateContent();
@@ -966,14 +966,14 @@ PACKET_HANDLER(EnterWorld)
     g_LastSpellIndex = 1;
     g_LastSkillIndex = 1;
 
-    CPacketClientVersion(g_Orion.ClientVersionText).Send();
+    CPacketClientVersion(g_Config.ClientVersionString).Send();
 
-    if (m_ClientVersion >= CV_200)
+    if (g_Config.ClientVersion >= CV_200)
     {
         CPacketGameWindowSize().Send();
     }
 
-    if (m_ClientVersion >= CV_200)
+    if (g_Config.ClientVersion >= CV_200)
     {
         CPacketLanguage(g_Language).Send();
     }
@@ -1102,7 +1102,7 @@ PACKET_HANDLER(NewHealthbarUpdate)
         return;
     }
 
-    if (*Start == 0x16 && m_ClientVersion < CV_500A)
+    if (*Start == 0x16 && g_Config.ClientVersion < CV_500A)
     {
         return;
     }
@@ -1125,7 +1125,7 @@ PACKET_HANDLER(NewHealthbarUpdate)
             uint8_t poisonFlag = 0x04;
             if (enable != 0u)
             {
-                if (m_ClientVersion >= CV_7000)
+                if (g_Config.ClientVersion >= CV_7000)
                 {
                     obj->SA_Poisoned = true;
                 }
@@ -1136,7 +1136,7 @@ PACKET_HANDLER(NewHealthbarUpdate)
             }
             else
             {
-                if (m_ClientVersion >= CV_7000)
+                if (g_Config.ClientVersion >= CV_7000)
                 {
                     obj->SA_Poisoned = false;
                 }
@@ -1299,7 +1299,7 @@ PACKET_HANDLER(CharacterStatus)
             }
             else
             {
-                if (m_ClientVersion >= CV_500A)
+                if (g_Config.ClientVersion >= CV_500A)
                 {
                     g_Player->MaxWeight = 7 * (g_Player->Str / 2) + 40;
                 }
@@ -1388,7 +1388,7 @@ PACKET_HANDLER(UpdateItem)
 
     uint16_t graphic = ReadUInt16BE();
 
-    if (g_TheAbyss && (graphic & 0x7FFF) == 0x0E5C)
+    if (g_Config.TheAbyss && (graphic & 0x7FFF) == 0x0E5C)
     {
         return;
     }
@@ -1590,7 +1590,7 @@ PACKET_HANDLER(UpdateObject)
         uint8_t layer = ReadUInt8();
         uint16_t itemColor = 0;
 
-        if (m_ClientVersion >= CV_70331)
+        if (g_Config.ClientVersion >= CV_70331)
         {
             itemColor = ReadUInt16BE();
         }
@@ -1705,7 +1705,7 @@ PACKET_HANDLER(UpdateContainedItem)
     uint16_t x = ReadUInt16BE();
     uint16_t y = ReadUInt16BE();
 
-    if (m_ClientVersion >= CV_6017)
+    if (g_Config.ClientVersion >= CV_6017)
     {
         Move(1);
     }
@@ -1736,7 +1736,7 @@ PACKET_HANDLER(UpdateContainedItems)
         uint16_t x = ReadUInt16BE();
         uint16_t y = ReadUInt16BE();
 
-        if (m_ClientVersion >= CV_6017)
+        if (g_Config.ClientVersion >= CV_6017)
         {
             Move(1);
         }
@@ -2163,7 +2163,7 @@ PACKET_HANDLER(OpenPaperdoll)
 PACKET_HANDLER(ClientVersion)
 {
     DEBUG_TRACE_FUNCTION;
-    CPacketClientVersion(g_Orion.ClientVersionText).Send();
+    CPacketClientVersion(g_Config.ClientVersionString).Send();
 }
 
 PACKET_HANDLER(Ping)
@@ -2276,7 +2276,7 @@ PACKET_HANDLER(LightLevel)
 PACKET_HANDLER(EnableLockedFeatures)
 {
     DEBUG_TRACE_FUNCTION;
-    if (m_ClientVersion >= CV_60142)
+    if (g_Config.ClientVersion >= CV_60142)
     {
         g_LockedClientFeatures = ReadUInt32BE();
     }
@@ -3891,7 +3891,7 @@ PACKET_HANDLER(AssistVersion)
 {
     DEBUG_TRACE_FUNCTION;
     uint32_t version = ReadUInt32BE();
-    CPacketAssistVersion(version, g_Orion.ClientVersionText).Send();
+    CPacketAssistVersion(version, g_Config.ClientVersionString).Send();
 }
 
 PACKET_HANDLER(CharacterListNotification)
@@ -4719,7 +4719,7 @@ void CPacketManager::AddHTMLGumps(CGump *gump, vector<HTMLGumpDataInfo> &list)
 
         CGUIHTMLText *htmlText = (CGUIHTMLText *)htmlGump->Add(new CGUIHTMLText(
             data.TextID,
-            (uint8_t)(m_ClientVersion >= CV_305D),
+            (uint8_t)(g_Config.ClientVersion >= CV_305D),
             color,
             0,
             0,
@@ -5128,7 +5128,7 @@ PACKET_HANDLER(OpenGump)
                 int graphic = ToInt(list[3]);
                 int color = 0;
 
-                if (listSize >= 5 && m_ClientVersion >= CV_305D)
+                if (listSize >= 5 && g_Config.ClientVersion >= CV_305D)
                 {
                     Wisp::CTextFileParser gumppicParser({}, "=", "", "");
                     vector<string> hueList = gumppicParser.GetTokens(list[4].c_str());
@@ -5441,7 +5441,7 @@ PACKET_HANDLER(DisplayMap)
 
     CGumpMap *gump = new CGumpMap(serial, gumpid, startX, startY, endX, endY, width, height);
 
-    if (*Start == 0xF5 || m_ClientVersion >= CV_308Z) //308z или выше?
+    if (*Start == 0xF5 || g_Config.ClientVersion >= CV_308Z) //308z или выше?
     {
         uint16_t facet = 0;
 
@@ -5739,8 +5739,8 @@ PACKET_HANDLER(OpenBook) // 0x93
     uint8_t flags = ReadUInt8();
     Move(1);
     auto pageCount = ReadUInt16BE();
-    CGumpBook *gump = new CGumpBook(
-        serial, 0, 0, pageCount, flags != 0, (g_PacketManager.GetClientVersion() >= CV_308Z));
+    CGumpBook *gump =
+        new CGumpBook(serial, 0, 0, pageCount, flags != 0, (g_Config.ClientVersion >= CV_308Z));
 
     gump->m_EntryTitle->m_Entry.SetTextA(ReadString(60));
     gump->m_EntryAuthor->m_Entry.SetTextA(ReadString(30));

--- a/OrionUO/Managers/PacketManager.h
+++ b/OrionUO/Managers/PacketManager.h
@@ -54,12 +54,8 @@ struct HTMLGumpDataInfo
 
 class CPacketManager : public Wisp::CPacketReader
 {
-protected:
-    CLIENT_VERSION m_ClientVersion = CV_OLD;
-
 public:
-    CLIENT_VERSION GetClientVersion() { return m_ClientVersion; };
-    void SetClientVersion(CLIENT_VERSION newClientVersion);
+    void ConfigureClientVersion(uint32_t newClientVersion);
     string AutoLoginNames = "";
     uint32_t ConfigSerial = 0;
 

--- a/OrionUO/Managers/PluginManager.cpp
+++ b/OrionUO/Managers/PluginManager.cpp
@@ -1,12 +1,16 @@
 ﻿// MIT License
 // Copyright (C) September 2016 Hotride
 
+#include "PluginManager.h"
+
 #if defined(ORION_WINDOWS)
 #include <Windows.h>
 #else
 #include <stdint.h>
 #define __cdecl
 #endif
+
+#include "../Config.h"
 
 CPluginManager g_PluginManager;
 

--- a/OrionUO/Managers/PluginManager.cpp
+++ b/OrionUO/Managers/PluginManager.cpp
@@ -59,8 +59,8 @@ CPlugin::CPlugin(uint32_t flags)
     m_PPS = new PLUGIN_INTERFACE();
     memset(m_PPS, 0, sizeof(PLUGIN_INTERFACE));
     m_PPS->Handle = g_OrionWindow.Handle;
-    m_PPS->ClientVersion = g_PacketManager.GetClientVersion();
-    m_PPS->ClientFlags = (g_FileManager.UseVerdata ? 0x01 : 0);
+    m_PPS->ClientVersion = g_Config.ClientVersion;
+    m_PPS->ClientFlags = (g_Config.UseVerdata ? 0x01 : 0);
 }
 
 CPlugin::~CPlugin()

--- a/OrionUO/Managers/ProfessionManager.cpp
+++ b/OrionUO/Managers/ProfessionManager.cpp
@@ -2,6 +2,9 @@
 // MIT License
 // Copyright (C) August 2016 Hotride
 
+#include "ProfessionManager.h"
+#include "../Config.h"
+
 CProfessionManager g_ProfessionManager;
 
 const string CProfessionManager::m_Keys[m_KeyCount] = {

--- a/OrionUO/Managers/ProfessionManager.cpp
+++ b/OrionUO/Managers/ProfessionManager.cpp
@@ -339,7 +339,7 @@ bool CProfessionManager::Load()
         apc->SetSkillIndex(2, 0xFF);
         apc->SetSkillIndex(3, 0xFF);
 
-        if (g_PacketManager.GetClientVersion() >= CV_70160)
+        if (g_Config.ClientVersion >= CV_70160)
         {
             apc->Str = 45;
             apc->Int = 35;

--- a/OrionUO/Managers/SpeechManager.cpp
+++ b/OrionUO/Managers/SpeechManager.cpp
@@ -189,7 +189,7 @@ bool CSpeechManager::LoadLangCodes()
 void CSpeechManager::GetKeywords(const wchar_t *text, vector<uint32_t> &codes)
 {
     DEBUG_TRACE_FUNCTION;
-    if (!m_Loaded || g_PacketManager.GetClientVersion() < CV_305D)
+    if (!m_Loaded || g_Config.ClientVersion < CV_305D)
     {
         return; // But in fact from the client version 2.0.7
     }

--- a/OrionUO/Managers/SpeechManager.cpp
+++ b/OrionUO/Managers/SpeechManager.cpp
@@ -1,6 +1,9 @@
 ﻿// MIT License
 // Copyright (C) August 2016 Hotride
 
+#include "SpeechManager.h"
+#include "../Config.h"
+
 CSpeechManager g_SpeechManager;
 
 CSpeechItem::CSpeechItem(uint16_t code, const wstring &data)

--- a/OrionUO/Network/Connection.cpp
+++ b/OrionUO/Network/Connection.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) August 2016 Hotride
 
 #include "../Sockets.h"
+#include "../Crypt/CryptEntry.h"
 
 CSocket::CSocket(bool gameSocket)
     : GameSocket(gameSocket)
@@ -229,19 +230,12 @@ vector<uint8_t> CSocket::Decompression(vector<uint8_t> data)
     DEBUG_TRACE_FUNCTION;
     if (GameSocket)
     {
-        intptr_t inSize = (intptr_t)data.size();
-
-        if (g_NetworkPostAction != nullptr)
-        {
-            g_NetworkPostAction(&data[0], &data[0], (int)inSize);
-        }
+        auto inSize = (intptr_t)data.size();
+        Crypt::Decrypt(&data[0], &data[0], (int)inSize);
 
         vector<uint8_t> decBuf(inSize * 4 + 2);
-
         int outSize = 65536;
-
         m_Decompressor((char *)&decBuf[0], (char *)&data[0], outSize, inSize);
-
         if (inSize != data.size())
         {
             DebugMsg("decompression buffer too small\n");
@@ -251,9 +245,7 @@ vector<uint8_t> CSocket::Decompression(vector<uint8_t> data)
         {
             decBuf.resize(outSize);
         }
-
         return decBuf;
     }
-
     return data;
 }

--- a/OrionUO/Network/Packets.cpp
+++ b/OrionUO/Network/Packets.cpp
@@ -1,6 +1,8 @@
 ﻿// MIT License
 // Copyright (C) August 2016 Hotride
 
+#include "../Config.h"
+
 CPacket::CPacket(size_t size, bool autoResize)
     : Wisp::CDataWriter(size, autoResize)
 {
@@ -19,7 +21,7 @@ CPacketFirstLogin::CPacketFirstLogin()
 {
     WriteUInt8(0x80);
 
-    if (g_TheAbyss)
+    if (g_Config.TheAbyss)
     {
         m_Data[61] = 0xFF;
     }
@@ -48,7 +50,7 @@ CPacketSecondLogin::CPacketSecondLogin()
 
     int passLen = 30;
 
-    if (g_TheAbyss)
+    if (g_Config.TheAbyss)
     {
         WriteUInt16BE(0xFF07);
         passLen = 28;
@@ -63,7 +65,7 @@ CPacketCreateCharacter::CPacketCreateCharacter(const string &name)
     int skillsCount = 3;
     uint32_t packetID = 0x00;
 
-    if (g_PacketManager.GetClientVersion() >= CV_70160)
+    if (g_Config.ClientVersion >= CV_70160)
     {
         skillsCount++;
         Resize(106, true);
@@ -81,7 +83,7 @@ CPacketCreateCharacter::CPacketCreateCharacter(const string &name)
     WriteUInt16BE(0x0000); //?
 
     uint32_t clientFlag = 0;
-    for (int i = 0; i < g_CharacterList.ClientFlag; i++)
+    for (int i = 0; i < g_Config.ClientFlag; i++)
     {
         clientFlag |= (1 << i);
     }
@@ -95,7 +97,7 @@ CPacketCreateCharacter::CPacketCreateCharacter(const string &name)
     WriteUInt8(val); //profession
     Move(15);        //?
 
-    if (g_PacketManager.GetClientVersion() < CV_4011D)
+    if (g_Config.ClientVersion < CV_4011D)
     {
         val = (uint8_t)g_CreateCharacterManager.GetFemale();
     }
@@ -103,7 +105,7 @@ CPacketCreateCharacter::CPacketCreateCharacter(const string &name)
     {
         val = (uint8_t)g_CreateCharacterManager.GetRace();
 
-        if (g_PacketManager.GetClientVersion() < CV_7000)
+        if (g_Config.ClientVersion < CV_7000)
         {
             val--;
         }
@@ -140,7 +142,7 @@ CPacketCreateCharacter::CPacketCreateCharacter(const string &name)
     WriteUInt16BE(g_CreateCharacterManager.GetBeard(g_CreateCharacterManager.BeardStyle).GraphicID);
     WriteUInt16BE(g_CreateCharacterManager.BeardColor);
 
-    if (g_PacketManager.GetClientVersion() >= CV_70160)
+    if (g_Config.ClientVersion >= CV_70160)
     {
         uint16_t location = g_SelectTownScreen.m_City->LocationIndex;
 
@@ -172,7 +174,7 @@ CPacketCreateCharacter::CPacketCreateCharacter(const string &name)
         WriteUInt8(serverIndex); //server index
 
         uint8_t location = g_SelectTownScreen.m_City->LocationIndex;
-        if (g_PacketManager.GetClientVersion() < CV_70130)
+        if (g_Config.ClientVersion < CV_70130)
         {
             location--;
         }
@@ -223,7 +225,7 @@ CPacketSelectCharacter::CPacketSelectCharacter(int index, const string &name)
 
     uint32_t clientFlag = 0;
 
-    for (int i = 0; i < g_CharacterList.ClientFlag; i++)
+    for (int i = 0; i < g_Config.ClientFlag; i++)
     {
         clientFlag |= (1 << i);
     }
@@ -452,7 +454,7 @@ CPacketUnicodeSpeechRequest::CPacketUnicodeSpeechRequest(
 CPacketCastSpell::CPacketCastSpell(int index)
     : CPacket(1)
 {
-    if (g_PacketManager.GetClientVersion() >= CV_60142)
+    if (g_Config.ClientVersion >= CV_60142)
     {
         Resize(9, true);
 
@@ -1043,7 +1045,7 @@ CPacketClientType::CPacketClientType()
 
     uint32_t clientFlag = 0;
 
-    for (int i = 0; i < g_CharacterList.ClientFlag; i++)
+    for (int i = 0; i < g_Config.ClientFlag; i++)
     {
         clientFlag |= (1 << i);
     }

--- a/OrionUO/OrionMain.cpp
+++ b/OrionUO/OrionMain.cpp
@@ -1,5 +1,8 @@
+// GPLv3 License
+// Copyright (C) 2019 Danny Angelo Carminati Grein
 
 #include "FileSystem.h"
+#include "Config.h"
 #include <SDL.h>
 #include <time.h>
 
@@ -19,6 +22,7 @@ int APIENTRY _tWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCm
     }
 
     g_App.Init();
+    LoadGlobalConfig();
     g_ConfigManager.Init();
     auto path = g_App.ExeFilePath("crashlogs");
     fs_path_create(path);
@@ -68,12 +72,7 @@ int APIENTRY _tWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCm
 
 #include "plugin/plugininterface.h"
 
-#if USE_ORIONDLL
-ENCRYPTION_TYPE g_EncryptionType;
-#endif
-
 static bool g_isHeadless = false;
-extern ENCRYPTION_TYPE g_EncryptionType;
 
 #if !defined(ORION_WINDOWS)
 ORION_EXPORT int plugin_main(int argc, char **argv)
@@ -82,20 +81,6 @@ int main(int argc, char **argv)
 #endif
 {
     DEBUG_TRACE_FUNCTION;
-
-    // TODO: good cli parsing api
-    // keep this simple for now just for travis-ci
-    for (int i = 0; i < argc; i++)
-    {
-        if (strcmp(argv[i], "--headless") == 0)
-        {
-            g_isHeadless = true;
-        }
-        else if (strcmp(argv[i], "--nocrypt") == 0)
-        {
-            g_EncryptionType = ET_NOCRYPT;
-        }
-    }
 
     if (SDL_Init(SDL_INIT_TIMER) < 0)
     {
@@ -107,11 +92,26 @@ int main(int argc, char **argv)
     SDL_Log("SDL Initialized.");
     g_App.Init();
     INITLOGGER("uolog.txt");
-    auto path = g_App.ExeFilePath("crashlogs");
-    fs_path_create(path);
+    LoadGlobalConfig();
+
+    // TODO: good cli parsing api
+    // keep this simple for now just for travis-ci
+    for (int i = 0; i < argc; i++)
+    {
+        if (strcmp(argv[i], "--headless") == 0)
+        {
+            g_isHeadless = true;
+        }
+        else if (strcmp(argv[i], "--nocrypt") == 0)
+        {
+            g_Config.EncryptionType = ET_NOCRYPT;
+        }
+    }
 
     // FIXME: log stuff
     /*
+    auto path = g_App.ExeFilePath("crashlogs");
+    fs_path_create(path);
     char buf[100]{};
     auto t = time(nullptr);
     auto now = *localtime(&t);

--- a/OrionUO/OrionUO.h
+++ b/OrionUO/OrionUO.h
@@ -11,7 +11,6 @@ bool __cdecl PluginSendFunction(uint8_t *buf, size_t size);
 class COrion
 {
 public:
-    string ClientVersionText = "2.0.3";
     int TexturesDataCount = 0;
     string m_OverrideServerAddress;
     int m_OverrideServerPort = 0;
@@ -37,7 +36,6 @@ private:
 
     string m_GameServerIP = "";
 
-    bool LoadClientConfig();
     void LoadAutoLoginNames();
     void LoadTiledata(int landSize, int staticsSize);
     void LoadIndexFiles();

--- a/OrionUO/ScreenStages/GameScreen.cpp
+++ b/OrionUO/ScreenStages/GameScreen.cpp
@@ -2193,7 +2193,7 @@ void CGameScreen::OnLeftMouseButtonUp()
                 else if (rwo->IsStaticObject() || rwo->IsMultiObject())
                 {
                     STATIC_TILES *st = nullptr;
-                    if (g_PacketManager.GetClientVersion() >= CV_7090 && rwo->IsSurface())
+                    if (g_Config.ClientVersion >= CV_7090 && rwo->IsSurface())
                     {
                         st = ((CRenderStaticObject *)rwo)->GetStaticData();
                     }
@@ -2304,7 +2304,7 @@ void CGameScreen::OnLeftMouseButtonUp()
                                     ->GetW(1020000 + id, true, g_Orion.m_StaticData[id].Name);
                             if (str.length() != 0u)
                             {
-                                if (g_PacketManager.GetClientVersion() >= CV_6000)
+                                if (g_Config.ClientVersion >= CV_6000)
                                 {
                                     g_Orion.CreateUnicodeTextMessage(
                                         TT_CLIENT, 0, 1, 0x03B2, str, rwo);

--- a/OrionUO/ScreenStages/GameScreen.cpp
+++ b/OrionUO/ScreenStages/GameScreen.cpp
@@ -1,8 +1,9 @@
 // MIT License
 // Copyright (C) August 2016 Hotride
 
-#include <SDL_rect.h>
 #include "GameScreen.h"
+#include <SDL_rect.h>
+#include "../Config.h"
 
 CGameScreen g_GameScreen;
 RENDER_VARIABLES_FOR_GAME_WINDOW g_RenderBounds;
@@ -609,9 +610,8 @@ void CGameScreen::AddTileToRenderList(
 
         bool aphaChanged = false;
 
-#if UO_RENDER_LIST_SORT == 1
         int z = obj->GetZ();
-
+#if UO_RENDER_LIST_SORT == 1
         int maxObjectZ = obj->PriorityZ;
 
         CRenderStaticObject *rso = obj->StaticGroupObjectPtr();

--- a/OrionUO/ScreenStages/MainScreen.cpp
+++ b/OrionUO/ScreenStages/MainScreen.cpp
@@ -1,66 +1,11 @@
 #include "MainScreen.h"
 #include "BaseScreen.h"
-#include "Platform.h"
+#include "../Config.h"
 #include "../GUI/GUITextEntry.h"
 #include "../Wisp/WispDefinitions.h"
 #include "../TextEngine/EntryText.h"
 
-#include "FileSystem.h"
-
-#define ORIONUO_CONFIG "OrionUO.cfg"
-
 CMainScreen g_MainScreen;
-
-enum
-{
-    MSCC_NONE,
-    MSCC_ACTID,
-    MSCC_ACTPWD,
-    MSCC_REMEMBERPWD,
-    MSCC_AUTOLOGIN,
-    MSCC_SMOOTHMONITOR,
-    MSCC_THE_ABYSS,
-    MSCC_ASMUT,
-    MSCC_CUSTOM_PATH,
-    MSCC_LOGIN_SERVER,
-    MSCC_COUNT,
-};
-
-namespace mscc
-{
-struct ConfigEntry
-{
-    uint32_t key;
-    const char *key_name;
-};
-
-static const ConfigEntry s_Keys[] = {
-    { MSCC_ACTID, "acctid" },
-    { MSCC_ACTPWD, "acctpassword" },
-    { MSCC_REMEMBERPWD, "rememberacctpw" },
-    { MSCC_AUTOLOGIN, "autologin" },
-    { MSCC_SMOOTHMONITOR, "smoothmonitor" },
-    { MSCC_THE_ABYSS, "theabyss" },
-    { MSCC_ASMUT, "asmut" },
-    { MSCC_CUSTOM_PATH, "custompath" },
-    { MSCC_LOGIN_SERVER, "loginserver" },
-    { MSCC_COUNT, nullptr },
-};
-
-static uint32_t GetConfigKey(const string &key)
-{
-    auto str = ToLowerA(key);
-    for (int i = 0; s_Keys[i].key_name; i++)
-    {
-        if (str == s_Keys[i].key_name)
-        {
-            return s_Keys[i].key;
-        }
-    }
-    return MSCC_NONE;
-}
-
-} // namespace mscc
 
 CMainScreen::CMainScreen()
     : CBaseScreen(m_MainGump)
@@ -85,16 +30,12 @@ void CMainScreen::Init()
     g_ConfigLoaded = false;
     g_GlobalScale = 1.0;
 
+    Load();
+
     g_OrionWindow.SetSize(Wisp::CSize(640, 480));
     g_OrionWindow.NoResize = true;
     g_OrionWindow.SetTitle("Ultima Online");
     g_GL.UpdateRect();
-
-    if (!m_SavePassword->Checked)
-    {
-        m_Password->SetTextW({});
-        m_MainGump.m_PasswordFake->SetTextW({});
-    }
 
     g_EntryPointer = m_MainGump.m_PasswordFake;
 
@@ -244,164 +185,44 @@ void CMainScreen::OnKeyDown(const KeyEvent &ev)
     m_Gump.WantRedraw = true;
 }
 
-// FIXME: Merge with LoadGlobalConfig and do it early in the executable load
-void CMainScreen::LoadCustomPath()
+void CMainScreen::Load()
 {
-    DEBUG_TRACE_FUNCTION;
-    LOG("Loading custom path from " ORIONUO_CONFIG "\n");
-    Wisp::CTextFileParser file(g_App.ExeFilePath(ORIONUO_CONFIG), "=", "#;", "");
-    while (!file.IsEOF())
+    m_AutoLogin->Checked = g_Config.AutoLogin;
+
+    m_Account->SetTextA(g_Config.Login);
+    m_Account->SetPos(checked_cast<int>(g_Config.Login.length()));
+
+    m_MainGump.m_PasswordFake->SetTextA("");
+    m_MainGump.m_PasswordFake->SetPos(0);
+
+    const size_t len = g_Config.Password.length();
+    if (len != 0)
     {
-        auto strings = file.ReadTokens(false);
-        if (strings.size() >= 2)
+        m_Password->SetTextA(g_Config.Password);
+        for (int zv = 0; zv < len; zv++)
         {
-            const auto key = mscc::GetConfigKey(strings[0]);
-            switch (key)
-            {
-                case MSCC_CUSTOM_PATH:
-                {
-                    g_App.m_UOPath = ToPath(strings[1]);
-                    fs_case_insensitive_init(g_App.m_UOPath);
-                }
-                break;
-
-                default:
-                    break;
-            }
+            m_MainGump.m_PasswordFake->Insert(L'*');
         }
-    }
-}
-
-void CMainScreen::LoadGlobalConfig()
-{
-    DEBUG_TRACE_FUNCTION;
-    m_AutoLogin->Checked = false;
-    g_ScreenEffectManager.Enabled = false;
-
-    LOG("Loading global config from " ORIONUO_CONFIG "\n");
-    Wisp::CTextFileParser file(g_App.ExeFilePath(ORIONUO_CONFIG), "=,", "#;", "");
-
-    while (!file.IsEOF())
-    {
-        auto strings = file.ReadTokens();
-        if (strings.size() >= 2)
-        {
-            const auto key = mscc::GetConfigKey(strings[0]);
-            LOG("Key: %d for %s\n", key, strings[0].c_str());
-            switch (key)
-            {
-                case MSCC_ACTID:
-                {
-                    m_Account->SetTextA(strings[1]);
-                    m_Account->SetPos((int)strings[1].length());
-                    break;
-                }
-                case MSCC_ACTPWD:
-                {
-                    string password = file.RawLine;
-                    size_t pos = password.find_first_of('=');
-                    password = password.substr(pos + 1, password.length() - (pos + 1));
-                    const auto len = (int)password.length();
-                    if (len != 0)
-                    {
-                        m_Password->SetTextA(password);
-                        for (int zv = 0; zv < len; zv++)
-                        {
-                            m_MainGump.m_PasswordFake->Insert(L'*');
-                        }
-                        m_Password->SetPos((int)len);
-                    }
-                    else
-                    {
-                        m_MainGump.m_PasswordFake->SetTextA("");
-                        m_MainGump.m_PasswordFake->SetPos(0);
-                        m_Password->SetTextA("");
-                        m_Password->SetPos(0);
-                    }
-                    break;
-                }
-                case MSCC_REMEMBERPWD:
-                {
-                    m_SavePassword->Checked = ToBool(strings[1]);
-                    if (!m_SavePassword->Checked)
-                    {
-                        m_MainGump.m_PasswordFake->SetTextA("");
-                        m_MainGump.m_PasswordFake->SetPos(0);
-                        m_Password->SetTextA("");
-                        m_Password->SetPos(0);
-                    }
-                    break;
-                }
-                case MSCC_AUTOLOGIN:
-                {
-                    m_AutoLogin->Checked = ToBool(strings[1]);
-                    break;
-                }
-                case MSCC_SMOOTHMONITOR:
-                {
-                    g_ScreenEffectManager.Enabled = ToBool(strings[1]);
-                    break;
-                }
-                case MSCC_THE_ABYSS:
-                {
-                    g_TheAbyss = ToBool(strings[1]);
-                    break;
-                }
-                case MSCC_ASMUT:
-                {
-                    g_Asmut = ToBool(strings[1]);
-                    break;
-                }
-                case MSCC_LOGIN_SERVER:
-                {
-                    g_App.m_ServerAddress = strings[1];
-                    g_App.m_ServerPort = ToInt(strings[2]);
-                    break;
-                }
-                default:
-                    break;
-            }
-        }
-    }
-}
-
-void CMainScreen::SaveGlobalConfig()
-{
-    DEBUG_TRACE_FUNCTION;
-    LOG("Saving global config to " ORIONUO_CONFIG "\n");
-    FILE *cfg = fs_open(g_App.ExeFilePath(ORIONUO_CONFIG), FS_WRITE);
-    if (cfg == nullptr)
-    {
-        return;
-    }
-
-    fprintf(cfg, "AcctID=%s\n", m_Account->c_str());
-    if (m_SavePassword->Checked)
-    {
-        fprintf(cfg, "AcctPassword=%s\n", m_Password->c_str());
-        fprintf(cfg, "RememberAcctPW=yes\n");
+        m_Password->SetPos(checked_cast<int>(len));
     }
     else
     {
-        fprintf(cfg, "AcctPassword=\n");
-        fprintf(cfg, "RememberAcctPW=no\n");
+        m_Password->SetTextA("");
+        m_Password->SetPos(0);
     }
 
-    fprintf(cfg, "AutoLogin=%s\n", (m_AutoLogin->Checked ? "yes" : "no"));
-    fprintf(cfg, "SmoothMonitor=%s\n", (g_ScreenEffectManager.Enabled ? "yes" : "no"));
-    fprintf(cfg, "TheAbyss=%s\n", (g_TheAbyss ? "yes" : "no"));
-    fprintf(cfg, "Asmut=%s\n", (g_Asmut ? "yes" : "no"));
-
-    if (g_App.m_UOPath != g_App.m_ExePath)
+    m_SavePassword->Checked = g_Config.SavePassword;
+    if (!m_SavePassword->Checked)
     {
-        fprintf(cfg, "CustomPath=%s\n", CStringFromPath(g_App.m_UOPath));
+        m_Password->SetTextW({});
+        m_MainGump.m_PasswordFake->SetTextW({});
     }
+}
 
-    if (!g_App.m_ServerAddress.empty())
-    {
-        fprintf(cfg, "LoginServer=%s,%d\n", g_App.m_ServerAddress.c_str(), g_App.m_ServerPort);
-    }
-
-    fflush(cfg);
-    fs_close(cfg);
+void CMainScreen::Save()
+{
+    g_Config.AutoLogin = m_AutoLogin->Checked;
+    g_Config.SavePassword = m_SavePassword->Checked;
+    g_Config.Password = m_Password->GetTextA();
+    g_Config.Login = m_Account->GetTextA();
 }

--- a/OrionUO/ScreenStages/MainScreen.h
+++ b/OrionUO/ScreenStages/MainScreen.h
@@ -7,6 +7,8 @@ class CMainScreen : public CBaseScreen
 private:
     CGumpScreenMain m_MainGump;
 
+    void Load();
+
 public:
     enum
     {
@@ -26,13 +28,12 @@ public:
     void SetAccounting(const string &account, const string &password);
     void Paste();
     void ProcessSmoothAction(uint8_t action = 0xFF);
-    void LoadGlobalConfig();
-    void LoadCustomPath();
-    void SaveGlobalConfig();
     void Init();
 
     virtual void OnTextInput(const TextEvent &ev) override;
     virtual void OnKeyDown(const KeyEvent &ev) override;
+
+    void Save();
 };
 
 extern CMainScreen g_MainScreen;

--- a/OrionUO/ScreenStages/SelectTownScreen.cpp
+++ b/OrionUO/ScreenStages/SelectTownScreen.cpp
@@ -15,7 +15,7 @@ CSelectTownScreen::~CSelectTownScreen()
 void CSelectTownScreen::Init()
 {
     DEBUG_TRACE_FUNCTION;
-    if (g_PacketManager.GetClientVersion() >= CV_70130)
+    if (g_Config.ClientVersion >= CV_70130)
     {
         m_City = g_CityList.GetCity(0);
     }

--- a/OrionUO/ScreenStages/SelectTownScreen.cpp
+++ b/OrionUO/ScreenStages/SelectTownScreen.cpp
@@ -1,6 +1,9 @@
 ﻿// MIT License
 // Copyright (C) August 2016 Hotride
 
+#include "SelectTownScreen.h"
+#include "../Config.h"
+
 CSelectTownScreen g_SelectTownScreen;
 
 CSelectTownScreen::CSelectTownScreen()

--- a/OrionUO/Target.cpp
+++ b/OrionUO/Target.cpp
@@ -373,7 +373,7 @@ void CTarget::LoadMulti(int offsetX, int offsetY, char offsetZ)
     {
         int itemOffset = sizeof(MULTI_BLOCK);
 
-        if (g_PacketManager.GetClientVersion() >= CV_7090)
+        if (g_Config.ClientVersion >= CV_7090)
         {
             itemOffset = sizeof(MULTI_BLOCK_NEW);
         }

--- a/OrionUO/Target.cpp
+++ b/OrionUO/Target.cpp
@@ -1,6 +1,9 @@
 // MIT License
 // Copyright (C) August 2016 Hotride
 
+#include "Target.h"
+#include "Config.h"
+
 CTarget g_Target;
 
 CTarget::CTarget()

--- a/OrionUO/TextEngine/EntryText.cpp
+++ b/OrionUO/TextEngine/EntryText.cpp
@@ -358,6 +358,7 @@ void CEntryText::SetTextA(const string &text)
     DEBUG_TRACE_FUNCTION;
     wstring wtext = ToWString(text);
     SetTextW(wtext);
+    m_CText = text;
 }
 
 void CEntryText::SetTextW(const wstring &text)

--- a/OrionUO/Wisp/WispApplication.cpp
+++ b/OrionUO/Wisp/WispApplication.cpp
@@ -16,7 +16,6 @@ void CApplication::Init()
     DEBUG_TRACE_FUNCTION;
     m_ExePath = fs_path_current();
     m_UOPath = fs_path_current();
-    g_MainScreen.LoadCustomPath();
 }
 
 CApplication::~CApplication()

--- a/OrionUO/Wisp/WispApplication.h
+++ b/OrionUO/Wisp/WispApplication.h
@@ -11,8 +11,6 @@ class CApplication
 public:
     os_path m_ExePath;
     os_path m_UOPath;
-    string m_ServerAddress;
-    uint16_t m_ServerPort = 2593;
 
 protected:
     virtual void OnMainLoop() {}

--- a/OrionUO/plugin/enumlist.h
+++ b/OrionUO/plugin/enumlist.h
@@ -61,7 +61,7 @@ enum CHARACTER_SPEED_TYPE
 {
     CST_NORMAL = 0,   // Normal speed
     CST_FAST_UNMOUNT, // Acceleration of the character's movement when it moves without a mount
-    CST_CANT_RUN, // Only walk, cannot run with or without a mount
+    CST_CANT_RUN,     // Only walk, cannot run with or without a mount
     CST_FAST_UNMOUNT_AND_CANT_RUN // Combine both previous: char cannot run and accelerate only if without mount
 };
 
@@ -75,36 +75,43 @@ enum ENCRYPTION_TYPE
     ET_TFISH // TwoFish + MD5
 };
 
-#define VERSION(a, b, c, d) (((a & 0xff) << 24) | ((b & 0xff) << 16) | ((c & 0xff) << 8) | (d & 0xff))
+#define VERSION(a, b, c, d)                                                                        \
+    (((a & 0xff) << 24) | ((b & 0xff) << 16) | ((c & 0xff) << 8) | (d & 0xff))
 
 enum CLIENT_VERSION
 {
-    CV_OLD   = VERSION(0, 0, 0, 0), // CF_T2A, Standard (<2.0.0)
-    CV_200   = VERSION(2, 0, 0, 0), // CF_RE, Packet sent with screen dimensions
-    CV_200X  = VERSION(2, 0, 0, 'x'), // Special Crypto keys
+    CV_OLD = VERSION(0, 0, 0, 0),    // CF_T2A, Standard (<2.0.0)
+    CV_200 = VERSION(2, 0, 0, 0),    // CF_RE, Packet sent with screen dimensions
+    CV_200X = VERSION(2, 0, 0, 'x'), // Special Crypto keys
     //CV_204C, // Introduced *.def files
-    CV_300   = VERSION(3, 0, 0, 0), // CF_TD
-    CV_305D  = VERSION(3, 0, 5, 'd'), // Using cliloc. Numer of slots in list of characters is equal to number of characters
-    CV_306E  = VERSION(3, 0, 6, 'e'), // Introduced packet with client type (0xBF subcmd 0x0F), uses mp3 instead of midi
-    CV_308   = VERSION(3, 0, 8, 0), // CF_LBR
-    CV_308D  = VERSION(3, 0, 8, 'd'), // Added "Maximum Stats" to the statusbar
-    CV_308J  = VERSION(3, 0, 8, 'j'), // Added "Followers" to the statsubar
-    CV_308Z  = VERSION(3, 0, 8, 'z'), // Added classes: paladin, necromancer; custom houses, 5 resistances, changed professions choice screen, removed "Save Password" checkbox
-    CV_400B  = VERSION(4, 0, 0, 'b'), // Removed tooltips
-    CV_405A  = VERSION(4, 0, 5, 'a'), // CF_SE, Added classes: ninja, samurai
+    CV_300 = VERSION(3, 0, 0, 0), // CF_TD
+    // Using cliloc. Numer of slots in list of characters is equal to number of characters
+    CV_305D = VERSION(3, 0, 5, 'd'),
+    // Introduced packet with client type (0xBF subcmd 0x0F), uses mp3 instead of midi
+    CV_306E = VERSION(3, 0, 6, 'e'),
+    CV_308 = VERSION(3, 0, 8, 0),    // CF_LBR
+    CV_308D = VERSION(3, 0, 8, 'd'), // Added "Maximum Stats" to the statusbar
+    CV_308J = VERSION(3, 0, 8, 'j'), // Added "Followers" to the statsubar
+    // Added classes: paladin, necromancer; custom houses, 5 resistances, changed professions choice screen, removed "Save Password" checkbox
+    CV_308Z = VERSION(3, 0, 8, 'z'),
+    CV_400B = VERSION(4, 0, 0, 'b'),   // Removed tooltips
+    CV_405A = VERSION(4, 0, 5, 'a'),   // CF_SE, Added classes: ninja, samurai
     CV_4011D = VERSION(4, 0, 11, 'd'), // Changed the character creation screen. Added elf race.
-    CV_500A  = VERSION(5, 0, 0, 'a'), // Paperdoll buttons replaced: Journal->Quests; Chat->Guild. Using Mega Cliloc, removed loading of Verdata.mul
-    CV_5020  = VERSION(5, 0, 2, 0), // Added buffs gump
-    CV_5090  = VERSION(5, 0, 9, 0), //
-    CV_6000  = VERSION(6, 0, 0, 0), // Added colors guild / alli chat, chat ignore. Options for a new system target, diplaying object properties, object handles
-    CV_6013  = VERSION(6, 0, 1, 3), //
-    CV_6017  = VERSION(6, 0, 1, 7), //
-    CV_6040  = VERSION(6, 0, 4, 0), // Increased number of character slots
-    CV_6060  = VERSION(6, 0, 6, 0), //
+    // Paperdoll buttons replaced: Journal->Quests; Chat->Guild. Using Mega Cliloc, removed loading of Verdata.mul
+    CV_500A = VERSION(5, 0, 0, 'a'),
+    CV_5020 = VERSION(5, 0, 2, 0), // Added buffs gump
+    CV_5090 = VERSION(5, 0, 9, 0), //
+    // Added colors guild / alli chat, chat ignore. Options for a new system target, diplaying object properties, object handles
+    CV_6000 = VERSION(6, 0, 0, 0),
+    CV_6013 = VERSION(6, 0, 1, 3),   //
+    CV_6017 = VERSION(6, 0, 1, 7),   //
+    CV_6040 = VERSION(6, 0, 4, 0),   // Increased number of character slots
+    CV_6060 = VERSION(6, 0, 6, 0),   //
     CV_60142 = VERSION(6, 0, 14, 2), //
-    CV_60144 = VERSION(6, 0, 14, 4), // CF_SA, Changed the character creation screen. Added gargoyle race
-    CV_7000  = VERSION(7, 0, 0, 0),  //
-    CV_7090  = VERSION(7, 0, 9, 0),  //
+    // CF_SA, Changed the character creation screen. Added gargoyle race
+    CV_60144 = VERSION(6, 0, 14, 4),
+    CV_7000 = VERSION(7, 0, 0, 0),   //
+    CV_7090 = VERSION(7, 0, 9, 0),   //
     CV_70130 = VERSION(7, 0, 13, 0), //
     CV_70160 = VERSION(7, 0, 16, 0), //
     CV_70180 = VERSION(7, 0, 18, 0), //

--- a/OrionUO/plugin/enumlist.h
+++ b/OrionUO/plugin/enumlist.h
@@ -50,61 +50,67 @@ enum SCAN_MODE_OBJECT
 
 enum EFFECT_TYPE
 {
-    EF_MOVING = 0,     //!Движется
-    EF_LIGHTING,       //!Удар молнией
-    EF_STAY_AT_POS,    //!Стоит на точке
-    EF_STAY_AT_SOURCE, //!Привязан к персонажу
-    EF_DRAG            //!Анимация перемещения предмета
+    EF_MOVING = 0,     // Moving
+    EF_LIGHTING,       // Lightning Strike
+    EF_STAY_AT_POS,    // Standing on position
+    EF_STAY_AT_SOURCE, // Tied to the source
+    EF_DRAG            // Item movement animation
 };
 
 enum CHARACTER_SPEED_TYPE
 {
-    CST_NORMAL = 0,   //!Нормальная скорость перемещения
-    CST_FAST_UNMOUNT, //!Ускорение движения персонажа, если он перемещается без маунта (выставляется скорость сопоставимая с маунтом)
-    CST_CANT_RUN, //!Персонаж может только ходить, не бежать (как на маунте, так и без него)
-    CST_FAST_UNMOUNT_AND_CANT_RUN //!Совокупность предыдущих 2 вариантов (персонаж не может бежать и ускорение только при перемещении без маунта)
+    CST_NORMAL = 0,   // Normal speed
+    CST_FAST_UNMOUNT, // Acceleration of the character's movement when it moves without a mount
+    CST_CANT_RUN, // Only walk, cannot run with or without a mount
+    CST_FAST_UNMOUNT_AND_CANT_RUN // Combine both previous: char cannot run and accelerate only if without mount
 };
 
 enum ENCRYPTION_TYPE
 {
-    ET_NOCRYPT = 0, //!Без шифрования
-    ET_OLD_BFISH,   //!Старое BlowFish
-    ET_1_25_36, //!Специальное для клиента 1.25.36 (BlowFish, изменен алгоритм логин шифрования)
-    ET_BFISH,   //!Стандартный BlowFish
-    ET_203,  //!Специальное для 2.0.3 клиента (BlowFish + TwoFish без MD5)
-    ET_TFISH //!TwoFish + MD5
+    ET_NOCRYPT = 0,
+    ET_OLD_BFISH,
+    ET_1_25_36, // Client specific: 1.25.36 (BlowFish, login encryption algo changed)
+    ET_BFISH,
+    ET_203,  // Special for client 2.0.3 (BlowFish + TwoFish without MD5)
+    ET_TFISH // TwoFish + MD5
 };
+
+#define VERSION(a, b, c, d) (((a & 0xff) << 24) | ((b & 0xff) << 16) | ((c & 0xff) << 8) | (d & 0xff))
 
 enum CLIENT_VERSION
 {
-    CV_OLD = 0, //Предшествующие клиенту 2.0.0, Остальные по логике, исходя из названия
-    CV_200,     //Отправляется пакет с габаритами экрана
-    //CV_204C,		//Использование *.def файлов
-    CV_305D, //Использование клилоков, количество слотов в списке персонажей равно количеству персонажей
-    CV_306E, //Добавлен пакет с типом клиента (0xBF subcmd 0x0F), использование mp3 вместо midi
-    CV_308D, //Добавлен параметр Maximum Stats в статусбар
-    CV_308J, //Добавлен параметр Followers в статусбар
-    CV_308Z, //Добавлены классы paladin, necromancer; custom houses, 5 resistances, изменено окно выбора профессии, убрана галочка Save Password
-    CV_400B, //Удаление тултипов
-    CV_405A, //Добавлены классы ninja, samurai
-    CV_4011D, //Изменение окна создания персонажа. Добавлена расса elves
-    CV_500A, //Кнопки папердолла заменены: Journal -> Quests; Chat -> Guild, использование Mega Cliloc, Убрана загрузка файла Verdata.mul
-    CV_5020, //Добавлен гамп бафов
-    CV_5090, //
-    CV_6000, //Добавлены цвета гильд/алли чата, игноры чатов. Добавлены опции новой таргет системы, вывод свойств предметов, Object Handles,
-    CV_6013, //
-    CV_6017, //
-    CV_6040, //Увеличилось количество слотов персонажей
-    CV_6060, //
-    CV_60142, //
-    CV_60144, //Изменение окна создания персонажа. Добавлена расса gargoyle
-    CV_7000,  //
-    CV_7090,  //
-    CV_70130, //
-    CV_70160, //
-    CV_70180, //
-    CV_70240, //*.mul -> *.uop
-    CV_70331  //
+    CV_OLD   = VERSION(0, 0, 0, 0), // CF_T2A, Standard (<2.0.0)
+    CV_200   = VERSION(2, 0, 0, 0), // CF_RE, Packet sent with screen dimensions
+    CV_200X  = VERSION(2, 0, 0, 'x'), // Special Crypto keys
+    //CV_204C, // Introduced *.def files
+    CV_300   = VERSION(3, 0, 0, 0), // CF_TD
+    CV_305D  = VERSION(3, 0, 5, 'd'), // Using cliloc. Numer of slots in list of characters is equal to number of characters
+    CV_306E  = VERSION(3, 0, 6, 'e'), // Introduced packet with client type (0xBF subcmd 0x0F), uses mp3 instead of midi
+    CV_308   = VERSION(3, 0, 8, 0), // CF_LBR
+    CV_308D  = VERSION(3, 0, 8, 'd'), // Added "Maximum Stats" to the statusbar
+    CV_308J  = VERSION(3, 0, 8, 'j'), // Added "Followers" to the statsubar
+    CV_308Z  = VERSION(3, 0, 8, 'z'), // Added classes: paladin, necromancer; custom houses, 5 resistances, changed professions choice screen, removed "Save Password" checkbox
+    CV_400B  = VERSION(4, 0, 0, 'b'), // Removed tooltips
+    CV_405A  = VERSION(4, 0, 5, 'a'), // CF_SE, Added classes: ninja, samurai
+    CV_4011D = VERSION(4, 0, 11, 'd'), // Changed the character creation screen. Added elf race.
+    CV_500A  = VERSION(5, 0, 0, 'a'), // Paperdoll buttons replaced: Journal->Quests; Chat->Guild. Using Mega Cliloc, removed loading of Verdata.mul
+    CV_5020  = VERSION(5, 0, 2, 0), // Added buffs gump
+    CV_5090  = VERSION(5, 0, 9, 0), //
+    CV_6000  = VERSION(6, 0, 0, 0), // Added colors guild / alli chat, chat ignore. Options for a new system target, diplaying object properties, object handles
+    CV_6013  = VERSION(6, 0, 1, 3), //
+    CV_6017  = VERSION(6, 0, 1, 7), //
+    CV_6040  = VERSION(6, 0, 4, 0), // Increased number of character slots
+    CV_6060  = VERSION(6, 0, 6, 0), //
+    CV_60142 = VERSION(6, 0, 14, 2), //
+    CV_60144 = VERSION(6, 0, 14, 4), // CF_SA, Changed the character creation screen. Added gargoyle race
+    CV_7000  = VERSION(7, 0, 0, 0),  //
+    CV_7090  = VERSION(7, 0, 9, 0),  //
+    CV_70130 = VERSION(7, 0, 13, 0), //
+    CV_70160 = VERSION(7, 0, 16, 0), //
+    CV_70180 = VERSION(7, 0, 18, 0), //
+    CV_70240 = VERSION(7, 0, 24, 0), // *.mul -> *.uop
+    CV_70331 = VERSION(7, 0, 33, 1), //
+    CV_LATEST = CV_70331,
 };
 
 enum CONNECTION_SCREEN_TYPE

--- a/docs/CONTRIBUTING/Compiling.md
+++ b/docs/CONTRIBUTING/Compiling.md
@@ -44,7 +44,7 @@ $ cd OrionUO
 $ ./OrionUO
 ```
 
-  > You'll need a `Client.cuo` and a `OrionUO.cfg` in the working directory. Inside `OrionUO.cfg` you need to add a line `CustomPath=/path/to/uo/data`, so OrionUO will be able to find your original client data files.
+  > You'll need a `OrionUO.cfg` in the working directory. Please use Orion Launcher to configure the client.
 
 ### MacOSX
 
@@ -67,6 +67,6 @@ $ ninja orion -j8
 $ cd OrionUO
 $ ./OrionUO
 ```
-  > You'll need a `Client.cuo` and a `OrionUO.cfg` in the working directory. Inside `OrionUO.cfg` you need to add line `CustomPath=/path/to/uo/data`, so OrionUO will be able to find your original client data files.
+  > You'll need a `OrionUO.cfg` in the working directory. Please use Orion Launcher to configure the client.
 
 Then you should have an `OrionUO` inside `build/OrionUO`


### PR DESCRIPTION
- Client.cuo is deprecated and not used anymore. Use OrionUO.cfg.

Client.cuo is more of trouble than useful. This will make all needed
configuration via OrionUO.cfg file and soon configurable via the
launcher itself instead yet another closed source component.

This change also refactor how the client version identifier is built up
by using a uint32_t composition for each element of the client version
in one of the two possibilities:
1. major.minor.revision.prototype
2. major.minor.revision(letter)

The subrevision letter gets converted in a prototype field with the
decimal value of the letter itself.

This should also fix #63 as it mostly refactor how the crypto keys are
calculated and used and by eliminating the crypto Install that converted
the byte buffer into another so orion could use, which wasn't ideal
anyway.

This changes the flow of loading and saving OrionUO.cfg as it is now
required to be one of the first thigs to run, even before command line
parsing that will be able to override configuration values in the
future.