### PR TITLE
Fixes #78 - Outlands send invalid direction when mobiles start to flee

### DIFF
--- a/OrionUO/Constants.h
+++ b/OrionUO/Constants.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+const int MAX_MOBILE_DIRECTIONS = 5;
+
 const int CONTAINERS_RECT_DEFAULT_POS = 40;
 
 const int CONTAINERS_RECT_LINESTEP = 800;

--- a/OrionUO/GameObjects/GameWorld.cpp
+++ b/OrionUO/GameObjects/GameWorld.cpp
@@ -131,7 +131,7 @@ void CGameWorld::ProcessAnimation()
 
                 int currentDelay = delay;
 
-                if (id < MAX_ANIMATIONS_DATA_INDEX_COUNT && dir < 5)
+                if (id < MAX_ANIMATIONS_DATA_INDEX_COUNT && dir < MAX_MOBILE_DIRECTIONS)
                 {
                     CTextureAnimationDirection &direction =
                         g_AnimationManager.m_DataIndex[id].m_Groups[animGroup].m_Direction[dir];
@@ -264,7 +264,7 @@ void CGameWorld::ProcessAnimation()
 
                 g_AnimationManager.GetAnimDirection(dir, mirror);
 
-                if (id < MAX_ANIMATIONS_DATA_INDEX_COUNT && dir < 5)
+                if (id < MAX_ANIMATIONS_DATA_INDEX_COUNT && dir < MAX_MOBILE_DIRECTIONS)
                 {
                     int animGroup = g_AnimationManager.GetDieGroupIndex(id, gi->UsedLayer != 0u);
 

--- a/OrionUO/Managers/AnimationManager.cpp
+++ b/OrionUO/Managers/AnimationManager.cpp
@@ -2,11 +2,12 @@
 // Copyright (C) August 2016 Hotride
 
 #include "AnimationManager.h"
+#include "../Constants.h"
 #include "../Config.h"
 
 CAnimationManager g_AnimationManager;
 
-const int CAnimationManager::m_UsedLayers[8][USED_LAYER_COUNT] = {
+const int CAnimationManager::m_UsedLayers[MAX_LAYER_DIRECTIONS][USED_LAYER_COUNT] = {
     {
         //dir 0
         OL_SHIRT, OL_PANTS, OL_SHOES,    OL_LEGS,   OL_TORSO,  OL_RING,   OL_TALISMAN, OL_BRACELET,
@@ -84,7 +85,7 @@ void CAnimationManager::UpdateAnimationAddressTable()
         {
             CTextureAnimationGroup &group = index.m_Groups[g];
 
-            for (int d = 0; d < 5; d++)
+            for (int d = 0; d < MAX_MOBILE_DIRECTIONS; d++)
             {
                 CTextureAnimationDirection &direction = group.m_Direction[d];
                 bool replace = (direction.FileIndex >= 4);
@@ -189,9 +190,9 @@ void CAnimationManager::Load(uint32_t *verdata)
         for (int j = 0; j < count; j++)
         {
             CTextureAnimationGroup &group = index.m_Groups[j];
-            int offset = (int)j * 5;
+            int offset = (int)j * MAX_MOBILE_DIRECTIONS;
 
-            for (int d = 0; d < 5; d++)
+            for (int d = 0; d < MAX_MOBILE_DIRECTIONS; d++)
             {
                 CTextureAnimationDirection &direction = group.m_Direction[d];
 
@@ -262,8 +263,8 @@ void CAnimationManager::Load(uint32_t *verdata)
                     id += 400;
                 }
 
-                group = offset / 5;
-                dir = offset % 5;
+                group = offset / MAX_MOBILE_DIRECTIONS;
+                dir = offset % MAX_MOBILE_DIRECTIONS;
 
                 if (id >= MAX_ANIMATIONS_DATA_INDEX_COUNT)
                 {
@@ -640,9 +641,9 @@ void CAnimationManager::InitIndexReplaces(uint32_t *verdata)
                     for (int j = 0; j < count; j++)
                     {
                         CTextureAnimationGroup &group = dataIndex.m_Groups[j];
-                        int offset = (int)j * 5;
+                        int offset = (int)j * MAX_MOBILE_DIRECTIONS;
 
-                        for (int d = 0; d < 5; d++)
+                        for (int d = 0; d < MAX_MOBILE_DIRECTIONS; d++)
                         {
                             CTextureAnimationDirection &direction = group.m_Direction[d];
 
@@ -739,7 +740,7 @@ void CAnimationManager::InitIndexReplaces(uint32_t *verdata)
                 CTextureAnimationGroup &group = dataIndex.m_Groups[j];
                 CTextureAnimationGroup &newGroup = checkDataIndex.m_Groups[j];
 
-                for (int d = 0; d < 5; d++)
+                for (int d = 0; d < MAX_MOBILE_DIRECTIONS; d++)
                 {
                     CTextureAnimationDirection &direction = group.m_Direction[d];
                     CTextureAnimationDirection &newDirection = newGroup.m_Direction[d];
@@ -839,7 +840,7 @@ void CAnimationManager::InitIndexReplaces(uint32_t *verdata)
                 CTextureAnimationGroup &group = dataIndex.m_Groups[ignoreGroups[j]];
                 CTextureAnimationGroup &newGroup = checkDataIndex.m_Groups[ignoreGroups[j]];
 
-                for (int d = 0; d < 5; d++)
+                for (int d = 0; d < MAX_MOBILE_DIRECTIONS; d++)
                 {
                     CTextureAnimationDirection &direction = group.m_Direction[d];
                     CTextureAnimationDirection &newDirection = newGroup.m_Direction[d];
@@ -1090,9 +1091,10 @@ bool CAnimationManager::TestPixels(
 
     if (id >= MAX_ANIMATIONS_DATA_INDEX_COUNT)
     {
-        return nullptr != nullptr;
+        return false;
     }
 
+    assert(Direction < MAX_MOBILE_DIRECTIONS && "Out-of-bound access");
     CTextureAnimationDirection &direction =
         m_DataIndex[id].m_Groups[AnimGroup].m_Direction[Direction];
     AnimID = id;
@@ -1169,6 +1171,7 @@ void CAnimationManager::Draw(
         return;
     }
 
+    assert(Direction < MAX_MOBILE_DIRECTIONS && "Out-of-bound access");
     CTextureAnimationDirection &direction =
         m_DataIndex[id].m_Groups[AnimGroup].m_Direction[Direction];
     AnimID = id;
@@ -1803,6 +1806,7 @@ void CAnimationManager::DrawCharacter(CGameCharacter *obj, int x, int y)
 
         if (id < MAX_ANIMATIONS_DATA_INDEX_COUNT)
         {
+            assert(Direction < MAX_MOBILE_DIRECTIONS && "Out-of-bound access");
             CTextureAnimationDirection &direction =
                 m_DataIndex[id].m_Groups[AnimGroup].m_Direction[Direction];
 
@@ -2095,7 +2099,7 @@ ANIMATION_DIMENSIONS CAnimationManager::GetAnimationDimensions(
 
     if (id < MAX_ANIMATIONS_DATA_INDEX_COUNT)
     {
-        if (dir < 5)
+        if (dir < MAX_MOBILE_DIRECTIONS)
         {
             CTextureAnimationDirection &direction =
                 m_DataIndex[id].m_Groups[animGroup].m_Direction[dir];
@@ -2497,6 +2501,7 @@ CAnimationManager::CollectFrameInformation(CGameObject *gameObject, bool checkLa
         {
             for (int l = 0; l < USED_LAYER_COUNT; l++)
             {
+                assert(layerDir < MAX_LAYER_DIRECTIONS && "Out-of-bounds access");
                 goi = obj->FindLayer(m_UsedLayers[layerDir][l]);
 
                 if (goi == nullptr || (goi->AnimID == 0u))
@@ -2537,6 +2542,7 @@ CAnimationManager::CollectFrameInformation(CGameObject *gameObject, bool checkLa
         {
             for (int l = 0; l < USED_LAYER_COUNT; l++)
             {
+                assert(Direction < MAX_LAYER_DIRECTIONS && "Out-of-bounds access");
                 CGameItem *goi = obj->FindLayer(m_UsedLayers[Direction][l]);
 
                 if (goi != nullptr && (goi->AnimID != 0u))

--- a/OrionUO/Managers/AnimationManager.h
+++ b/OrionUO/Managers/AnimationManager.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+static const int MAX_LAYER_DIRECTIONS = 8;
 static const float UPPER_BODY_RATIO = 0.35f;
 static const float MID_BODY_RATIO = 0.60f;
 static const float LOWER_BODY_RATIO = 0.94f;
@@ -83,7 +84,7 @@ private:
     CEquipConvData *m_EquipConvItem{ nullptr };
 
     static const int USED_LAYER_COUNT = 23;
-    static const int m_UsedLayers[8][USED_LAYER_COUNT];
+    static const int m_UsedLayers[MAX_LAYER_DIRECTIONS][USED_LAYER_COUNT];
 
     vector<std::pair<uint16_t, uint8_t>> m_GroupReplaces[2];
 

--- a/OrionUO/TextureObject.h
+++ b/OrionUO/TextureObject.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "Constants.h"
+
 struct UOPAnimationData
 {
     os_path path;
@@ -49,6 +51,6 @@ public:
     CTextureAnimationGroup();
     virtual ~CTextureAnimationGroup();
 
-    CTextureAnimationDirection m_Direction[5];
+    CTextureAnimationDirection m_Direction[MAX_MOBILE_DIRECTIONS];
     UOPAnimationData m_UOPAnimData;
 };

--- a/README.md
+++ b/README.md
@@ -3,12 +3,9 @@
 [![Travis Build Status](https://travis-ci.org/OrionUO/OrionUO.svg?branch=master)](https://travis-ci.org/OrionUO/OrionUO)
 [![Build status](https://ci.appveyor.com/api/projects/status/gmkwveaysxb12uog?svg=true)](https://ci.appveyor.com/project/fungos/orionuo)
 
+* Supported Platforms: Windows 7, Windows 10, Linux and MacOSX.
 
-* OrionUO Client - is a linux fork of OrioUO Open Source Ultima Online client.
-
-* Platforms: Windows 7, Windows 10, Linux and MacOSX.
-
-* Rendering: OpenGL 2.0 and higher.
+* Graphics: OpenGL 2.0 and higher.
 
 ### Downloading OrionUO
 
@@ -19,3 +16,7 @@
 ## Contributing
 
 Please read [CONTRIBUTING](docs/CONTRIBUTING.md) before doing any contribution to the project.
+
+## Building
+
+For instructions about building from source, read the section [Compiling](docs/CONTRIBUTING/Compiling.md).


### PR DESCRIPTION
Packet 0x77 (UpdateCharacter) may receive what seems to be an invalid
direction 8 (that should have been 0). Looks like a bug server side.
This clamp possible direction values to what RunUO expects to be valid but
do not check (ValueMask) and add asserts in places where it could crash
before.

Add MAX_MOBILE_DIRECTIONS constant.
Add MAX_LAYER_DIRECTIONS constant.

Import possible fix for Issue #46. Tested on RunUO servers and didn't
notice a difference, so if this fixes the issue on POL lets bring it in.

Minor update in the README with direct link to instructions on how to
compile.

- Fix issue with POL server where wasn't possible to pass through a NPC.
- Fix crash on Outlands with mobiles that flee combat.