### PR TITLE
#57 Local file processing should depend on local configuration not on…

### DIFF
--- a/OrionUO/Managers/AnimationManager.cpp
+++ b/OrionUO/Managers/AnimationManager.cpp
@@ -92,11 +92,11 @@ void CAnimationManager::UpdateAnimationAddressTable()
 
                 if (direction.FileIndex == 2)
                 {
-                    replace = ((g_LockedClientFeatures & LFF_LBR) != 0u);
+                    replace = (g_Config.ClientFlag >= CF_LBR);
                 }
                 else if (direction.FileIndex == 3)
                 {
-                    replace = ((g_LockedClientFeatures & LFF_AOS) != 0u);
+                    replace = (g_Config.ClientFlag >= CF_AOS);
                 }
                 //else if (direction.FileIndex == 4)
                 //	replace = (g_LockedClientFeatures & LFF_AOS);


### PR DESCRIPTION
… configuration sent by server.

It seems that it is because Sphere 0.99 behavior, it sends wrong value in `EnableLockedFeatures` when user is still in game when attempting to log in. So `g_LockedClientFeatures & LFF_LBR` is zero in `CAnimationManager::UpdateAnimationAddressTable`. Which means that `PatchedAddress` is not assigned to `Address` and `ReadFramesPixelData` access wrong memory when it loads animation data.