### PR TITLE
#89 Fixing animation data format detection.

### DIFF
--- a/OrionUO/Managers/AnimationManager.cpp
+++ b/OrionUO/Managers/AnimationManager.cpp
@@ -92,11 +92,11 @@ void CAnimationManager::UpdateAnimationAddressTable()
 
                 if (direction.FileIndex == 2)
                 {
-                    replace = ((g_LockedClientFeatures & LFF_LBR) != 0u);
+                    replace = (g_Config.ClientFlag >= CF_LBR);
                 }
                 else if (direction.FileIndex == 3)
                 {
-                    replace = ((g_LockedClientFeatures & LFF_AOS) != 0u);
+                    replace = (g_Config.ClientFlag >= CF_AOS);
                 }
                 //else if (direction.FileIndex == 4)
                 //	replace = (g_LockedClientFeatures & LFF_AOS);


### PR DESCRIPTION
When character is still in the game and player attempts to log in, the client jumps into the game without character selection - it means client doesn't send character selection packet (0x5d) to the server. This packet contains `clientflag` containing information about features supported by the client (say LBR - 0x04). In this case server doesn't know features supported by the client and sends packet 0xB9 (Enable locked client features) with some default feature bitflag (say T2A - 0). It's value can be incompatible with actual client file format on player's computer.

So `g_LockedClientFeatures & LFF_LBR` can be zero in `CAnimationManager::UpdateAnimationAddressTable`. Which means that `PatchedAddress` is not assigned to `Address` and `ReadFramesPixelData` access wrong memory when it loads animation data.