### PR TITLE
set default cli version to CV_LATEST

### DIFF
--- a/OrionUO/Config.h
+++ b/OrionUO/Config.h
@@ -24,7 +24,7 @@ struct Config
     uint32_t Key1 = 0;
     uint32_t Key2 = 0;
     uint32_t Key3 = 0;
-    uint32_t ClientVersion = 0;
+    uint32_t ClientVersion = CV_LATEST;
     uint32_t EncryptionType = 0;
 };
 


### PR DESCRIPTION
I'm assuming the intended behavior when a client version isn't specified (i.e., no 'clientVersion' in the config file) is to assume the client version is CV_LATEST, my assumption comes from the following code:
https://github.com/OrionUO/OrionUO/blob/06cde77317c19a20fe0888dcc2ad191afd7883e8/OrionUO/Config.cpp#L89

Right now, this isn't possible as the config client version is initialized to 0 instead of CV_LATEST, making all further version conditions to fail (e.g., https://github.com/OrionUO/OrionUO/blob/06cde77317c19a20fe0888dcc2ad191afd7883e8/OrionUO/Managers/FileManager.cpp#L79)

